### PR TITLE
Use specific Block names in accessor methods in Block classes

### DIFF
--- a/src/main/java/org/unigram/docvalidator/parser/PlainTextParser.java
+++ b/src/main/java/org/unigram/docvalidator/parser/PlainTextParser.java
@@ -41,7 +41,7 @@ public final class PlainTextParser extends AbstractDocumentParser {
       e1.printStackTrace();
     }
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(new Section(0, ""));
+    fileContent.appendSection(new Section(0, ""));
     Section currentSection = fileContent.getLastSection();
     currentSection.appendParagraph(new Paragraph());
     try {

--- a/src/main/java/org/unigram/docvalidator/parser/WikiParser.java
+++ b/src/main/java/org/unigram/docvalidator/parser/WikiParser.java
@@ -47,7 +47,7 @@ public final class WikiParser extends AbstractDocumentParser {
     FileContent doc = new FileContent();
     //for sentences right below the begging of document
     Section currentSection = new Section(0, "");
-    doc.appendChild(currentSection);
+    doc.appendSection(currentSection);
     LinePattern prevPattern = LinePattern.VOID;
     LinePattern currentPattern = LinePattern.VOID;
     try {
@@ -61,7 +61,7 @@ public final class WikiParser extends AbstractDocumentParser {
           currentPattern = LinePattern.HEADER;
           Integer level = Integer.valueOf(head.get(0));
           Section tmpSection =  new Section(level, head.get(1));
-          doc.appendChild(tmpSection);
+          doc.appendSection(tmpSection);
           if (!addChild(currentSection, tmpSection)) {
             LOG.warn("Failed to add parent for a Seciotn: "
                 + tmpSection.getHeaderContent());
@@ -95,13 +95,13 @@ public final class WikiParser extends AbstractDocumentParser {
 
   private boolean addChild(Section candidate, Section child) {
     if (candidate.getLevel() < child.getLevel()) {
-      candidate.appendChild(child);
+      candidate.appendSection(child);
       child.setParent(candidate);
     } else { // search parent
       Section parent = candidate.getParent();
       while (parent != null) {
         if (parent.getLevel() < child.getBlockID()) {
-          parent.appendChild(child);
+          parent.appendSection(child);
           child.setParent(parent);
           candidate = child;
           break;

--- a/src/main/java/org/unigram/docvalidator/store/Document.java
+++ b/src/main/java/org/unigram/docvalidator/store/Document.java
@@ -26,7 +26,7 @@ public final class Document implements Block {
     return files.lastElement();
   }
 
-  public int getSizeOfChildren() {
+  public int getFileNumber() {
     return files.size();
   }
 

--- a/src/main/java/org/unigram/docvalidator/store/FileContent.java
+++ b/src/main/java/org/unigram/docvalidator/store/FileContent.java
@@ -21,16 +21,16 @@ public final class FileContent implements Block {
    * get Iterator for Section in the FileContent.
    * @return Iterator of Section list
    */
-  public Iterator<Section> getChilds() {
+  public Iterator<Section> getSections() {
     return sections.iterator();
   }
 
   /**
    * add Section.
-   * @param childBlock
+   * @param section
    */
-  public void appendChild(Section childBlock) {
-     sections.add(childBlock);
+  public void appendSection(Section section) {
+     sections.add(section);
   }
 
   /**
@@ -45,7 +45,7 @@ public final class FileContent implements Block {
    * get the size of Sections.
    * @return size of Sections
    */
-  public int getSizeOfChildren() {
+  public int getSizeOfSections() {
     return sections.size();
   }
 

--- a/src/main/java/org/unigram/docvalidator/store/List.java
+++ b/src/main/java/org/unigram/docvalidator/store/List.java
@@ -19,7 +19,7 @@ public final class List implements Block {
    * get iterator of list elements.
    * @return Iterator of ListElement
    */
-  public Iterator<ListElement> getChilds() {
+  public Iterator<ListElement> getListElements() {
     return listElements.iterator();
   }
 
@@ -27,7 +27,7 @@ public final class List implements Block {
    * get the number of list elements.
    * @return number of list elements
    */
-  public int getSizeOfChildren() {
+  public int getNumberOfListElements() {
     return listElements.size();
   }
 

--- a/src/main/java/org/unigram/docvalidator/store/Paragraph.java
+++ b/src/main/java/org/unigram/docvalidator/store/Paragraph.java
@@ -18,7 +18,7 @@ public final class Paragraph implements Block {
    * get the iterator of sentences.
    * @return Iterator of Sentence in the paragraph
    */
-  public Iterator<Sentence> getChilds() {
+  public Iterator<Sentence> getSentences() {
     return sentences.iterator();
   }
 
@@ -31,8 +31,8 @@ public final class Paragraph implements Block {
     return sentences.get(lineNumber);
   }
 
-  public void appendSentence(String childBlock, int lineNum) {
-    sentences.add(new Sentence(childBlock, lineNum));
+  public void appendSentence(String content, int lineNum) {
+    sentences.add(new Sentence(content, lineNum));
   }
 
   public int getNumverOfSentences() {

--- a/src/main/java/org/unigram/docvalidator/store/Section.java
+++ b/src/main/java/org/unigram/docvalidator/store/Section.java
@@ -9,14 +9,14 @@ import java.util.Vector;
 public final class Section implements Block {
   /**
    * constructor.
-   * @param l section level
+   * @param sectioLevel section level
    * @param header header content string
    */
-  public Section(int l, String header) {
+  public Section(int sectioLevel, String header) {
     super();
-    this.level = l;
+    this.level = sectioLevel;
     this.headerContent = header;
-    this.children = new Vector<Section>();
+    this.subsections = new Vector<Section>();
     this.paragraphs = new Vector<Paragraph>();
     this.lists = new Vector<List>();
   }
@@ -25,16 +25,16 @@ public final class Section implements Block {
    * get the iterator of subsections.
    * @return Iterator of Section
    */
-  public Iterator<Section> getChilds() {
-    return children.iterator();
+  public Iterator<Section> getSeubsections() {
+    return subsections.iterator();
   }
 
   /**
    * add a subsection.
-   * @param childBlock
+   * @param section section
    */
-  public void appendChild(Section childBlock) {
-    children.add(childBlock);
+  public void appendSection(Section section) {
+    subsections.add(section);
   }
 
   /**
@@ -47,26 +47,26 @@ public final class Section implements Block {
 
   /**
    * set level of section.
-   * @param l section level
+   * @param sectionLevel section level
    */
-  public void setHeaderLevel(int l) {
-    this.level = l;
+  public void setHeaderLevel(int sectionLevel) {
+    this.level = sectionLevel;
   }
 
   /**
    * Set super section.
-   * @param p super section
+   * @param parentSectionp super section
    */
-  public void setParent(Section p) {
-    this.parent = p;
+  public void setParent(Section parentSection) {
+    this.parent = parentSection;
   }
 
   /**
    * get the size of subsections.
    * @return size of subsection
    */
-  public int getSizeOfChildren() {
-    return children.size();
+  public int getNumberOfSubsections() {
+    return subsections.size();
   }
 
   /**
@@ -89,8 +89,8 @@ public final class Section implements Block {
    * get last subsection.
    * @return last subsection in this section
    */
-  public Section getLastChildSection() {
-    return children.lastElement();
+  public Section getLastSubsection() {
+    return subsections.lastElement();
   }
 
   /**
@@ -162,8 +162,8 @@ public final class Section implements Block {
   /* parent Section */
   private Section parent;
 
-  /* child secitons */
-  private Vector<Section> children;
+  /* subsecitons */
+  private Vector<Section> subsections;
 
   /* paragrahs in this section. */
   private Vector<Paragraph> paragraphs;

--- a/src/main/java/org/unigram/docvalidator/validator/SectionValidator.java
+++ b/src/main/java/org/unigram/docvalidator/validator/SectionValidator.java
@@ -18,7 +18,7 @@ public abstract class SectionValidator implements Validator {
       ResultDistributor distributor) {
     List<ValidationError> validationErrors = new ArrayList<ValidationError>();
     for (Iterator<Section> sectionIterator =
-        file.getChilds(); sectionIterator.hasNext();) {
+        file.getSections(); sectionIterator.hasNext();) {
       Section currentSection = sectionIterator.next();
       validationErrors.addAll(this.check(currentSection));
     }

--- a/src/main/java/org/unigram/docvalidator/validator/SentenceIterator.java
+++ b/src/main/java/org/unigram/docvalidator/validator/SentenceIterator.java
@@ -43,7 +43,7 @@ public class SentenceIterator implements Validator {
         this.lineValidators.iterator(); iterator.hasNext();) {
       SentenceValidator validator = iterator.next();
       for (Iterator<Section> sectionIterator =
-            file.getChilds(); sectionIterator.hasNext();) {
+            file.getSections(); sectionIterator.hasNext();) {
         Section currentSection = sectionIterator.next();
         checkSection(distributor, errors, validator,
             currentSection, file.getFileName());
@@ -93,7 +93,7 @@ public class SentenceIterator implements Validator {
         currentSection.getParagraph(); paraIterator.hasNext();) {
       Paragraph currentParagraph = paraIterator.next();
       for (Iterator<Sentence> lineIterator =
-          currentParagraph.getChilds(); lineIterator.hasNext();) {
+          currentParagraph.getSentences(); lineIterator.hasNext();) {
         List<ValidationError> validationErrors =
             validator.check(lineIterator.next());
         for (Iterator<ValidationError> errorIterator =

--- a/src/main/java/org/unigram/docvalidator/validator/section/SectionLengthValidator.java
+++ b/src/main/java/org/unigram/docvalidator/validator/section/SectionLengthValidator.java
@@ -31,7 +31,7 @@ public class SectionLengthValidator extends SectionValidator {
         section.getParagraph(); paraIterator.hasNext();) {
       Paragraph currentPraParagraph = paraIterator.next();
       for (Iterator<Sentence> sentenceIterator =
-          currentPraParagraph.getChilds(); sentenceIterator.hasNext();) {
+          currentPraParagraph.getSentences(); sentenceIterator.hasNext();) {
         Sentence sentence = sentenceIterator.next();
         sectionCharNumber += sentence.content.length();
       }

--- a/src/test/java/org/unigram/docvalidator/parser/WikiParserTest.java
+++ b/src/test/java/org/unigram/docvalidator/parser/WikiParserTest.java
@@ -62,7 +62,7 @@ public class WikiParserTest {
     InputStream is = new ByteArrayInputStream(sampleText.getBytes("utf-8")); 
     try {
       FileContent doc = parser.generateDocument(is);
-      Iterator<Section> sections = doc.getChilds();
+      Iterator<Section> sections = doc.getSections();
       int sectionNum = 0;
       Vector<Section> sectionBlocks =new Vector<Section>();
       while(sections.hasNext()) {
@@ -71,7 +71,7 @@ public class WikiParserTest {
       }
       assertEquals(3, sectionNum);
       assertEquals(1,doc.getLastSection().getSizeofLists());
-      assertEquals(5,doc.getLastSection().getLastListBlock().getSizeOfChildren());
+      assertEquals(5,doc.getLastSection().getLastListBlock().getNumberOfListElements());
       Iterator<Paragraph> paragraph = doc.getLastSection().getParagraph();
       int pcount = 0;
       while (paragraph.hasNext()) {
@@ -100,7 +100,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(3, firstParagraph.getNumverOfSentences());
       for (int i=0; i<expectedResult.length; i++) {
@@ -125,7 +125,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(5, firstParagraph.getNumverOfSentences());
     } catch (DocumentValidatorException e) {
@@ -146,7 +146,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       assertEquals(false, firstSections.getParagraph().hasNext());
     } catch (DocumentValidatorException e) {
       fail();
@@ -166,10 +166,10 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(3, firstParagraph.getNumverOfSentences());
-      Iterator<Sentence> siter = firstParagraph.getChilds();
+      Iterator<Sentence> siter = firstParagraph.getSentences();
       while(siter.hasNext()) {
         Sentence s= siter.next();
         assertEquals(s.content, ".");
@@ -192,7 +192,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(2, firstParagraph.getNumverOfSentences());
     } catch (DocumentValidatorException e) {
@@ -216,7 +216,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(2, firstParagraph.getNumverOfSentences());
     } catch (DocumentValidatorException e) {
@@ -259,7 +259,7 @@ public class WikiParserTest {
     }
     try {
       FileContent doc = parser.generateDocument(is);
-      Section firstSections = doc.getChilds().next();
+      Section firstSections = doc.getSections().next();
       Paragraph firstParagraph = firstSections.getParagraph().next();
       assertEquals(2, firstParagraph.getNumverOfSentences());
     } catch (DocumentValidatorException e) {

--- a/src/test/java/org/unigram/docvalidator/validator/section/ParagraphNumberValidatorTest.java
+++ b/src/test/java/org/unigram/docvalidator/validator/section/ParagraphNumberValidatorTest.java
@@ -32,7 +32,7 @@ public class ParagraphNumberValidatorTest {
     section.appendParagraph(new Paragraph());
 
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(section);
+    fileContent.appendSection(section);
 
     List<ValidationError> errors = validator.check(fileContent,
         new FakeResultDistributor());
@@ -48,7 +48,7 @@ public class ParagraphNumberValidatorTest {
     section.appendParagraph(new Paragraph());
 
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(section);
+    fileContent.appendSection(section);
 
     List<ValidationError> errors = validator.check(fileContent,
         new FakeResultDistributor());

--- a/src/test/java/org/unigram/docvalidator/validator/section/ParagraphStartWithValidatorTest.java
+++ b/src/test/java/org/unigram/docvalidator/validator/section/ParagraphStartWithValidatorTest.java
@@ -21,7 +21,7 @@ public class ParagraphStartWithValidatorTest {
     paragraph.appendSentence("it like a piece of a cake.", 0);
     section.appendParagraph(paragraph);
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(section);
+    fileContent.appendSection(section);
     List<ValidationError> errors = validator.check(fileContent, new FakeResultDistributor());
     assertEquals(1, errors.size());
   }
@@ -34,7 +34,7 @@ public class ParagraphStartWithValidatorTest {
     paragraph.appendSentence(" it like a piece of a cake.", 0);
     section.appendParagraph(paragraph);
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(section);
+    fileContent.appendSection(section);
     List<ValidationError> errors = validator.check(fileContent, new FakeResultDistributor());
     assertEquals(0, errors.size());
   }

--- a/src/test/java/org/unigram/docvalidator/validator/section/SectionLengthValidatorTest.java
+++ b/src/test/java/org/unigram/docvalidator/validator/section/SectionLengthValidatorTest.java
@@ -31,7 +31,7 @@ public class SectionLengthValidatorTest {
     paragraph.appendSentence("it like a piece of a cake.", 0);
     section.appendParagraph(paragraph);
     FileContent fileContent = new FileContent();
-    fileContent.appendChild(section);
+    fileContent.appendSection(section);
 
     List<ValidationError> errors = validator.check(fileContent, new FakeResultDistributor());
     assertEquals(1, errors.size());


### PR DESCRIPTION
Replaced accessor method name to use specific Block names.

For example, the getSizeOfChildren method in Document class is renamed into getFileNumber.
