### PR TITLE
Add findbugs plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
     </plugins>
   </build>
 
@@ -123,6 +128,15 @@
         <version>2.10</version>
         <configuration>
           <configLocation>src/main/resources/checkstyle.xml</configLocation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <effort>Max</effort>
+          <xmlOutput>false</xmlOutput>
+          <outputEncoding>UTF-8</outputEncoding>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
added findbugs plugin.

note: when the default locale is not en, user should specify the locale with the following command before running findbugs.

> export JAVA_TOOL_OPTIONS="-Duser.language=en"
> mvn findbugs:findbugs
