### PR TITLE
Change License of remainig files to Apache 2.0

### DIFF
--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/DocumentValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/DocumentValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SectionValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SectionValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SentenceIterator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SentenceIterator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SentenceValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/SentenceValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/Validator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/Validator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/ValidatorFactory.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/ValidatorFactory.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/ParagraphNumberValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/ParagraphNumberValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.section;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/ParagraphStartWithValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/ParagraphStartWithValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.section;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/SectionLengthValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/section/SectionLengthValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.section;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/CommaNumberValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/CommaNumberValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/InvalidCharacterValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/InvalidCharacterValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/InvalidExpressionValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/InvalidExpressionValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/QuotationValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/QuotationValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SentenceLengthValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SentenceLengthValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SpaceBeginningOfSentenceValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SpaceBeginningOfSentenceValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SuggestExpressionValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SuggestExpressionValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SymbolWithSpaceValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/SymbolWithSpaceValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/WordNumberValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/WordNumberValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence;
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/lang/ja/KatakanaEndHyphenValidator.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/validator/sentence/lang/ja/KatakanaEndHyphenValidator.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence.lang.ja;
 

--- a/document-validator-core/src/test/java/org/unigram/docvalidator/validator/sentence/lang/ja/KatakanaSpellCheckValidatorTest.java
+++ b/document-validator-core/src/test/java/org/unigram/docvalidator/validator/sentence/lang/ja/KatakanaSpellCheckValidatorTest.java
@@ -1,19 +1,19 @@
 /**
- * DocumentValidator
- * Copyright (c) 2013-, Takahiko Ito, All rights reserved.
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.unigram.docvalidator.validator.sentence.lang.ja;
 


### PR DESCRIPTION
This patch replaces the license of source files which are forgotten to be replaced to Apache 2.0 in Issue #110.
This patch fixes Issue #36.
