### PR TITLE
Add a document builder class for testing #107

### DIFF
--- a/document-validator-core/src/test/java/org/unigram/docvalidator/SampleDocumentGenerator.java
+++ b/document-validator-core/src/test/java/org/unigram/docvalidator/SampleDocumentGenerator.java
@@ -45,28 +45,13 @@ public class SampleDocumentGenerator {
    */
   public static Document generateOneFileDocument(String docString,
       String type) throws DocumentValidatorException {
-    if (docString == null) {
-      throw new DocumentValidatorException("Input string is null");
-    }
-
-    Parser parser;
-    try {
-      DVResource resource = new DVResource(
-          new ValidatorConfiguration("dummy"), new CharacterTable());
-      parser = DocumentParserFactory.generate(type, resource);
-    } catch (DocumentValidatorException e) {
-      throw new DocumentValidatorException(
-          "Failed to create a parser: " + e.getMessage());
-    }
+    DVResource resource = new DVResource(
+        new ValidatorConfiguration("dummy"), new CharacterTable());
+    Parser parser = DocumentParserFactory.generate(type, resource);
 
     InputStream stream = IOUtils.toInputStream(docString);
     Document document = new Document();
-    try {
-      document.appendFile(parser.generateDocument(stream));
-    } catch (DocumentValidatorException e) {
-      throw new DocumentValidatorException(
-          "Failed to parse input document: " + e.getMessage());
-    }
+    document.appendFile(parser.generateDocument(stream));
     return document;
   }
 }

--- a/document-validator-core/src/test/java/org/unigram/docvalidator/SampleDocumentGeneratorTest.java
+++ b/document-validator-core/src/test/java/org/unigram/docvalidator/SampleDocumentGeneratorTest.java
@@ -72,4 +72,9 @@ public class SampleDocumentGeneratorTest {
     assertEquals("Gekioko pun pun maru means very very angry.", doc.getFile(0).getSection(1)
         .getParagraph(0).getSentence(0).content);
   }
+
+  @Test(expected=NullPointerException.class)
+  public void testInputNullDocument() throws DocumentValidatorException {
+    SampleDocumentGenerator.generateOneFileDocument(null, "markdown");
+  }
 }


### PR DESCRIPTION
I added a document builder class. The class would be useful for simplify the test cases which we need to create sample documents. 

Fix Issue #107.
