### PR TITLE
Make docvalid command runnable from arbitary directories

### DIFF
--- a/document-validator-app/bin/docvalid
+++ b/document-validator-app/bin/docvalid
@@ -2,7 +2,7 @@
 
 VERSION=0.1
 RUN_SCRIPT="$(basename "${0}")"
-DV_HOME=`dirname "$this"`
+DV_HOME=${DV_HOME:-`dirname "$this"`}
 MAIN_CLASS="org.unigram.docvalidator.Main"
 
 usage() {


### PR DESCRIPTION
This patch make redpen run from arbitary directories when user add a environment variable DV_HOME as follows

```
$ export DV_HOME=/home/ito/document-validaor
$ docvalid -c blahblah ...
```
