### PR TITLE
 refactor document-validator-server using DocumentParserFactory instead of Parser Constructor  fix checkstyle error in DocumentValidateResource

### DIFF
--- a/document-validator-core/src/main/java/org/unigram/docvalidator/parser/MarkdownParser.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/parser/MarkdownParser.java
@@ -48,6 +48,9 @@ public class MarkdownParser extends BasicDocumentParser {
           + Extensions.AUTOLINKS
           + Extensions.FENCED_CODE_BLOCKS);
 
+  MarkdownParser() {
+    super();
+  }
 
   @Override
   public FileContent generateDocument(String fileName)

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/parser/PlainTextParser.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/parser/PlainTextParser.java
@@ -39,7 +39,7 @@ public final class PlainTextParser extends BasicDocumentParser {
   /**
    * Constructor.
    */
-  public PlainTextParser() {
+  PlainTextParser() {
     super();
   }
 

--- a/document-validator-core/src/main/java/org/unigram/docvalidator/parser/WikiParser.java
+++ b/document-validator-core/src/main/java/org/unigram/docvalidator/parser/WikiParser.java
@@ -43,7 +43,7 @@ public final class WikiParser extends BasicDocumentParser {
   /**
    * Constructor.
    */
-  public WikiParser() {
+  WikiParser() {
     super();
   }
 

--- a/document-validator-server/src/main/java/org/unigram/docvalidator/server/api/DocumentValidateResource.java
+++ b/document-validator-server/src/main/java/org/unigram/docvalidator/server/api/DocumentValidateResource.java
@@ -23,7 +23,8 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.unigram.docvalidator.parser.PlainTextParser;
+import org.unigram.docvalidator.parser.DocumentParserFactory;
+import org.unigram.docvalidator.parser.Parser;
 import org.unigram.docvalidator.server.DocumentValidatorServer;
 import org.unigram.docvalidator.store.Document;
 import org.unigram.docvalidator.store.FileContent;
@@ -47,7 +48,7 @@ import java.util.List;
 @Path("/document")
 public class DocumentValidateResource {
 
-  private static final Logger log = LogManager.getLogger(
+  private static final Logger LOG = LogManager.getLogger(
     DocumentValidateResource.class
   );
 
@@ -58,15 +59,15 @@ public class DocumentValidateResource {
                                      String document) throws
     JSONException, DocumentValidatorException, UnsupportedEncodingException {
 
-    log.info("Validating document");
+    LOG.info("Validating document");
 
     DocumentValidatorServer server = DocumentValidatorServer.getInstance();
     JSONObject json = new JSONObject();
 
     json.put("document", document);
 
-    PlainTextParser parser = new PlainTextParser();
-    parser.initialize(server.getDocumentValidatorResource());
+    Parser parser = DocumentParserFactory.generate(
+        "plain", server.getDocumentValidatorResource());
     FileContent fileContent = parser.generateDocument(new
       ByteArrayInputStream(document.getBytes("UTF-8")));
 


### PR DESCRIPTION
refactor document-validator-server using DocumentParserFactory instead of Parser Constructor
fix checkstyle error in DocumentValidateResource
