### PR TITLE
Fix ParagraphStartiwhtValidator

### DIFF
--- a/redpen-core/src/main/java/org/bigram/docvalidator/validator/section/ParagraphStartWithValidator.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/validator/section/ParagraphStartWithValidator.java
@@ -56,8 +56,10 @@ public class ParagraphStartWithValidator extends AbstractSectionValidator {
   @Override
   public List<ValidationError> validate(Section section) {
     List<ValidationError> validationErrors = new ArrayList<ValidationError>();
-
     for (Paragraph currentParagraph : section.getParagraphs()) {
+      if (currentParagraph.getNumberOfSentences() == 0) {
+        continue;
+      }
       Sentence firstSentence = currentParagraph.getSentence(0);
       if (firstSentence.content.indexOf(this.beginningOfParagraph) != 0) {
         validationErrors.add(new ValidationError(

--- a/redpen-core/src/test/java/org/bigram/docvalidator/parser/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/org/bigram/docvalidator/parser/PlainTextParserTest.java
@@ -117,6 +117,25 @@ public class PlainTextParserTest {
   }
 
   @Test
+  public void testGenerateDocumentWithTailingReturns() {
+    String sampleText = "";
+    sampleText += "This is a pen.\n";
+    sampleText += "That is a orange.\n";
+    sampleText += "\n";
+    sampleText += "However, pen is not oranges.\n";
+    sampleText += "We need to be peisient.\n";
+    sampleText += "\n";
+    sampleText += "\n";
+    Document doc = generateDocument(sampleText);
+    Section section = doc.getLastSection();
+    assertEquals(4, extractParagraphs(section).size());
+    assertEquals(2, extractParagraphs(section).get(0).getNumberOfSentences());
+    assertEquals(2, extractParagraphs(section).get(1).getNumberOfSentences());
+    assertEquals(0, extractParagraphs(section).get(2).getNumberOfSentences());
+    assertEquals(0, extractParagraphs(section).get(3).getNumberOfSentences());
+  }
+
+  @Test
   public void testGenerateDocumentWithMultipleSentenceInOneLine() {
     String sampleText = "Tokyu is a good railway company. ";
     sampleText += "The company is reliable. In addition it is rich. ";

--- a/redpen-core/src/test/java/org/bigram/docvalidator/validator/section/ParagraphStartWithValidatorTest.java
+++ b/redpen-core/src/test/java/org/bigram/docvalidator/validator/section/ParagraphStartWithValidatorTest.java
@@ -51,4 +51,13 @@ public class ParagraphStartWithValidatorTest {
     assertEquals(0, errors.size());
   }
 
+  @Test
+  public void testVoidParagraph() {
+    ParagraphStartWithValidator validator = new ParagraphStartWithValidator();
+    Section section = new Section(0);
+    Paragraph paragraph = new Paragraph();
+    section.appendParagraph(paragraph);
+    List<ValidationError> errors = validator.validate(section);
+    assertEquals(0, errors.size());
+  }
 }


### PR DESCRIPTION
ParagraphStartWithValidator failed when input paragraphs do not have any sentence. This patch fixes the failure.
