### PR TITLE
Remove iterator config

### DIFF
--- a/redpen-app/sample/conf/validation-conf-en.xml
+++ b/redpen-app/sample/conf/validation-conf-en.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0"?>
 <component name="Validator">
-
-  <component name="SentenceIterator">
-    <component name="SentenceLength">
-      <property name="max_length" value="200"/>
-    </component>
-    <component name="InvalidCharacter" />
-    <component name="SpaceWithSymbol" />
+  <component name="SentenceLength">
+    <property name="max_length" value="200"/>
   </component>
-
+  <component name="InvalidCharacter" />
+  <component name="SpaceWithSymbol" />
   <component name="SectionLength">
     <property name="max_char_num" value="2000"/>
   </component>

--- a/redpen-app/sample/conf/validation-conf-ja.xml
+++ b/redpen-app/sample/conf/validation-conf-ja.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0"?>
 <component name="Validator">
-
-  <component name="SentenceIterator">
-    <component name="SentenceLength">
-      <property name="max_length" value="100"/>
-    </component>
-    <component name="InvalidCharacter" />
-    <component name="KatakanaEndHyphen"/>
-    <component name="KatakanaSpellCheck" />
+  <component name="SentenceLength">
+    <property name="max_length" value="100"/>
   </component>
-
+  <component name="InvalidCharacter" />
+  <component name="KatakanaEndHyphen"/>
+  <component name="KatakanaSpellCheck" />
   <component name="SectionLength">
     <property name="max_char_number" value="1500"/>
   </component>

--- a/redpen-core/src/main/java/org/bigram/docvalidator/config/Configuration.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/config/Configuration.java
@@ -40,14 +40,33 @@ public final class Configuration {
    * @param validatorConfig settings of validators
    * @param characterConf settings of characters and symbols
    */
-  public Configuration(ValidatorConfiguration validatorConfig, CharacterTable characterConf) {
+  public Configuration(ValidatorConfiguration validatorConfig,
+      CharacterTable characterConf) {
     super();
     this.characterTable = characterConf;
 
     // TODO tricky implementation. this code is need to refactor with ConfigurationLoader.
     for (ValidatorConfiguration config : validatorConfig.getChildren()) {
-      if ("SentenceIterator".equals(config.getConfigurationName())) {
-        this.sentenceValidatorConfigs.addAll(config.getChildren());
+      if ("SentenceLength".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("InvalidExpression".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("SpaceAfterPeriod".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("CommaNumber".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("WordNumber".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("SuggestExpression".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("InvalidCharacter".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("SpaceWithSymbol".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("KatakanaEndHyphen".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
+      } else if ("KatakanaSpellCheck".equals(config.getConfigurationName())) {
+        sentenceValidatorConfigs.add(config);
       } else if ("SectionLength".equals(config.getConfigurationName())) {
         this.sectionValidatorConfigs.add(config);
       } else if ("MaxParagraphNumber".equals(config.getConfigurationName())) {
@@ -55,7 +74,8 @@ public final class Configuration {
       } else if ("ParagraphStartWith".equals(config.getConfigurationName())) {
         this.sectionValidatorConfigs.add(config);
       } else {
-        LOG.warn("No validator such as '" +config.getConfigurationName() + "'");
+        throw new IllegalStateException("No Validator such as '"
+            + config.getConfigurationName() + "'");
       }
     }
   }

--- a/redpen-core/src/test/java/org/bigram/docvalidator/DocumentValidatorTest.java
+++ b/redpen-core/src/test/java/org/bigram/docvalidator/DocumentValidatorTest.java
@@ -143,10 +143,8 @@ public class DocumentValidatorTest {
         ValidationConfigurationLoader.loadConfiguration(
             new ReaderInputStream(new StringReader("<?xml version=\"1.0\"?>\n" +
                 "<component name=\"Validator\">" +
-                "  <component name=\"SentenceIterator\">" +
-                "    <component name=\"SentenceLength\">\n" +
-                "      <property name=\"max_length\" value=\"5\"/>\n" +
-                "    </component>" +
+                "  <component name=\"SentenceLength\">\n" +
+                "    <property name=\"max_length\" value=\"5\"/>\n" +
                 "  </component>" +
                 "</component>"
             ))

--- a/redpen-core/src/test/java/org/bigram/docvalidator/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/org/bigram/docvalidator/config/ConfigurationTest.java
@@ -18,8 +18,6 @@
 
 package org.bigram.docvalidator.config;
 
-import org.bigram.docvalidator.config.Configuration;
-import org.bigram.docvalidator.config.ValidatorConfiguration;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -30,9 +28,8 @@ import static org.junit.Assert.*;
 public class ConfigurationTest {
 
   @Test
-  public void testSentenceIteratorConfiguration() throws Exception {
+  public void testSentencValidatorConfiguration() throws Exception {
     ValidatorConfiguration rootConfig = new ValidatorConfiguration("top");
-    ValidatorConfiguration sentenceIteratorConfig = new ValidatorConfiguration("SentenceIterator");
 
     ValidatorConfiguration configSentenceLength = new ValidatorConfiguration("SentenceLength");
     ValidatorConfiguration configInvalidExpression = new ValidatorConfiguration("InvalidExpression");
@@ -43,63 +40,33 @@ public class ConfigurationTest {
     ValidatorConfiguration configInvalidCharacter = new ValidatorConfiguration("InvalidCharacter");
     ValidatorConfiguration configSpaceWithSymbol = new ValidatorConfiguration("SpaceWithSymbol");
     ValidatorConfiguration configKatakanaEndHyphen = new ValidatorConfiguration("KatakanaEndHyphen");
-    ValidatorConfiguration configKatakanaSpellCheckValidator = new ValidatorConfiguration("KatakanaSpellCheckValidator");
+    ValidatorConfiguration configKatakanaSpellCheckValidator = new ValidatorConfiguration("KatakanaSpellCheck");
 
-    sentenceIteratorConfig.addChild(configSentenceLength);
-    sentenceIteratorConfig.addChild(configInvalidExpression);
-    sentenceIteratorConfig.addChild(configSpaceAfterPeriod);
-    sentenceIteratorConfig.addChild(configCommaNumber);
-    sentenceIteratorConfig.addChild(configWordNumber);
-    sentenceIteratorConfig.addChild(configSuggestExpression);
-    sentenceIteratorConfig.addChild(configInvalidCharacter);
-    sentenceIteratorConfig.addChild(configSpaceWithSymbol);
-    sentenceIteratorConfig.addChild(configKatakanaEndHyphen);
-    sentenceIteratorConfig.addChild(configKatakanaSpellCheckValidator);
-
-    rootConfig.addChild(sentenceIteratorConfig);
+    rootConfig.addChild(configSentenceLength);
+    rootConfig.addChild(configInvalidExpression);
+    rootConfig.addChild(configSpaceAfterPeriod);
+    rootConfig.addChild(configCommaNumber);
+    rootConfig.addChild(configWordNumber);
+    rootConfig.addChild(configSuggestExpression);
+    rootConfig.addChild(configInvalidCharacter);
+    rootConfig.addChild(configSpaceWithSymbol);
+    rootConfig.addChild(configKatakanaEndHyphen);
+    rootConfig.addChild(configKatakanaSpellCheckValidator);
 
     Configuration configuration = new Configuration(rootConfig);
     assertEquals(10, configuration.getSentenceValidatorConfigs().size());
-
   }
 
-  @Test
-  public void testInvalidNestedSentenceValidatorConfiguration() throws Exception{
+  @Test(expected = IllegalStateException.class)
+  public void testInvalidValidatorConfiguration() {
     ValidatorConfiguration rootConfig = new ValidatorConfiguration("top");
-
-    ValidatorConfiguration sentenceIteratorConfig = new ValidatorConfiguration("NotSentenceIterator");
-
-    ValidatorConfiguration configSentenceLength = new ValidatorConfiguration("SentenceLength");
-    ValidatorConfiguration configInvalidExpression = new ValidatorConfiguration("InvalidExpression");
-    ValidatorConfiguration configSpaceAfterPeriod = new ValidatorConfiguration("SpaceAfterPeriod");
-    ValidatorConfiguration configCommaNumber = new ValidatorConfiguration("CommaNumber");
-    ValidatorConfiguration configWordNumber = new ValidatorConfiguration("WordNumber");
-    ValidatorConfiguration configSuggestExpression = new ValidatorConfiguration("SuggestExpression");
-    ValidatorConfiguration configInvalidCharacter = new ValidatorConfiguration("InvalidCharacter");
-    ValidatorConfiguration configSpaceWithSymbol = new ValidatorConfiguration("SpaceWithSymbol");
-    ValidatorConfiguration configKatakanaEndHyphen = new ValidatorConfiguration("KatakanaEndHyphen");
-    ValidatorConfiguration configKatakanaSpellCheckValidator = new ValidatorConfiguration("KatakanaSpellCheckValidator");
-
-
-    sentenceIteratorConfig.addChild(configSentenceLength);
-    sentenceIteratorConfig.addChild(configInvalidExpression);
-    sentenceIteratorConfig.addChild(configSpaceAfterPeriod);
-    sentenceIteratorConfig.addChild(configCommaNumber);
-    sentenceIteratorConfig.addChild(configWordNumber);
-    sentenceIteratorConfig.addChild(configSuggestExpression);
-    sentenceIteratorConfig.addChild(configInvalidCharacter);
-    sentenceIteratorConfig.addChild(configSpaceWithSymbol);
-    sentenceIteratorConfig.addChild(configKatakanaEndHyphen);
-    sentenceIteratorConfig.addChild(configKatakanaSpellCheckValidator);
-    rootConfig.addChild(sentenceIteratorConfig);
-
+    ValidatorConfiguration configInvalid = new ValidatorConfiguration("ThereIsNo");
+    rootConfig.addChild(configInvalid);
     Configuration configuration = new Configuration(rootConfig);
-    assertEquals(0, configuration.getSentenceValidatorConfigs().size());
-
   }
 
   @Test
-  public void testConfiguration() throws Exception{
+  public void testSectionValidatorConfiguration() throws Exception{
     ValidatorConfiguration rootConfig = new ValidatorConfiguration("top");
 
     ValidatorConfiguration configSectionLength = new ValidatorConfiguration("SectionLength");
@@ -112,8 +79,5 @@ public class ConfigurationTest {
 
     Configuration configuration = new Configuration(rootConfig);
     assertEquals(3, configuration.getSectionValidatorConfigs().size());
-
   }
-
-
 }

--- a/redpen-core/src/test/java/org/bigram/docvalidator/parser/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/org/bigram/docvalidator/parser/PlainTextParserTest.java
@@ -78,10 +78,8 @@ public class PlainTextParserTest {
   private String sampleConfiguraitonStr = "" +
     "<?xml version=\"1.0\"?>" +
     "<component name=\"Validator\">" +
-    "  <component name=\"SentenceIterator\">" +
-    "    <component name=\"LineLength\">" +
-    "      <property name=\"max_length\" value=\"10\"/>" +
-    "    </component>" +
+    "  <component name=\"SentenceLength\">" +
+    "    <property name=\"max_length\" value=\"10\"/>" +
     "  </component>" +
     "</component>";
 

--- a/redpen-server/src/main/resources/conf/validation-conf.xml
+++ b/redpen-server/src/main/resources/conf/validation-conf.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
 <component name="Validator">
-
-  <component name="SentenceIterator">
-    <component name="SentenceLength">
-      <property name="max_length" value="50"/>
-    </component>
-    <component name="SpaceAfterPeriod" />
-    <component name="InvalidCharacter" />
-    <component name="SpaceWithSymbol" />
+  <component name="SentenceLength">
+    <property name="max_length" value="200"/>
   </component>
-
+  <component name="SpaceAfterPeriod" />
+  <component name="InvalidCharacter" />
+  <component name="SpaceWithSymbol" />
   <component name="SectionLength">
     <property name="max_char_number" value="50"/>
   </component>
   <component name="ParagraphStartWith" />
-
 </component>


### PR DESCRIPTION
Removed SentenceIterator from validator configuration.

Current configuration

```
<component name="Validator">
   <component name="SentenceIterator">
       <component name="SentenceLength"/>
       <component name="SpaceAfterPeriod" />
   </component>
</component>
```

New configuration.

```
<component name="Validator">
    <component name="SentenceLength"/>
    <component name="SpaceAfterPeriod" />
</component>
```

Ref #166. 
