### PR TITLE
fixes #185 - implement DocumentValidator initialization process in a ServletContextListener instead of a Servlet

### DIFF
--- a/redpen-server/src/main/java/org/bigram/docvalidator/server/DocumentValidatorInitializer.java
+++ b/redpen-server/src/main/java/org/bigram/docvalidator/server/DocumentValidatorInitializer.java
@@ -22,20 +22,20 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bigram.docvalidator.DocumentValidatorException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 /**
  * Initiation of the document validator server.
  */
-public class DocumentValidatorInitServlet extends HttpServlet {
+public class DocumentValidatorInitializer implements ServletContextListener {
 
   private static Logger log = LogManager.getLogger(
-    DocumentValidatorInitServlet.class
+    DocumentValidatorInitializer.class
   );
 
   @Override
-  public void init() throws ServletException {
+  public void contextInitialized(ServletContextEvent servletContextEvent) {
     log.info("Starting Document Validator Server.");
     try {
       DocumentValidatorServer.initialize();
@@ -46,7 +46,7 @@ public class DocumentValidatorInitServlet extends HttpServlet {
   }
 
   @Override
-  public void destroy() {
+  public void contextDestroyed(ServletContextEvent servletContextEvent) {
     log.info("Stopping Document Validator Server.");
   }
 }

--- a/redpen-server/src/main/webapp/WEB-INF/web.xml
+++ b/redpen-server/src/main/webapp/WEB-INF/web.xml
@@ -6,13 +6,11 @@
   <display-name>RedPen Server</display-name>
   <description>RedPen Server</description>
 
-  <servlet>
-    <servlet-name>initServlet</servlet-name>
-    <servlet-class>
-        org.bigram.docvalidator.server.DocumentValidatorInitServlet
-    </servlet-class>
-    <load-on-startup>1</load-on-startup>
-  </servlet>
+  <listener>
+    <listener-class>
+        org.bigram.docvalidator.server.DocumentValidatorInitializer
+    </listener-class>
+  </listener>
 
   <!-- Wink SDK servlet configuration. This servlet handles HTTP requests of
   SDK web service on application server. -->


### PR DESCRIPTION
fixes #185 - implement DocumentValidator initialization process in a ServletContextListener instead of a Servlet
