### PR TITLE
[redpen-server]fix: set maven-compiler with source level 1.6 to build

### DIFF
--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -16,6 +16,14 @@
     <finalName>redpen-server</finalName>
     <plugins>
       <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-compiler-plugin</artifactId>
+           <configuration>
+                <source>1.6</source>
+                <target>1.6</target>
+           </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.mortbay.jetty</groupId>
         <artifactId>maven-jetty-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
In Ubuntu(java version 1.7.0_55, mvn version 3.0.5), `mvn install` failed to build redpen-server.
Errors below:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project redpen-server: Compilation failure: Compilation failure:
[ERROR] /home/redpen/redpen/redpen-server/src/main/java/org/bigram/docvalidator/server/api/DocumentValidateResource.java:[48,1] error: annotations are not supported in -source 1.3
[ERROR]
...
```

It is because `maven-compiler-plugin` default use source level 1.3.
So I added specified its source version `1.6`.
Thanks.
