### PR TITLE
suppress build warnings

### DIFF
--- a/redpen-app/pom.xml
+++ b/redpen-app/pom.xml
@@ -23,6 +23,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version>
             <configuration>
                 <source>1.8</source>
                 <target>1.8</target>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -44,6 +44,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version>
             <configuration>
                 <source>1.8</source>
                 <target>1.8</target>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -18,6 +18,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -35,6 +36,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>2.4</version>
         <configuration>
           <archive>
             <manifest>
@@ -93,6 +95,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.16</version>
         <configuration>
           <additionalClasspathElements>
               <additionalClasspathElement>${basedir}/src/main/webapp/WEB-INF</additionalClasspathElement>


### PR DESCRIPTION
plugin versions need to be explicitly specified to suppress following warning messages:

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.unigram:redpen-core:jar:0.6
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 44, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.unigram:redpen-app:jar:0.6
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 23, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.unigram:redpen-server:war:0.6
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 18, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 93, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-war-plugin is missing. @ line 35, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
