### PR TITLE
stop using Throwable

### DIFF
--- a/redpen-core/src/main/java/org/bigram/docvalidator/ConfigurationLoader.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/ConfigurationLoader.java
@@ -211,13 +211,7 @@ public class ConfigurationLoader {
       DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
       dBuilder.setErrorHandler(new SAXErrorHandler());
       doc = dBuilder.parse(input);
-    } catch (SAXException e) {
-      LOG.error(e.getMessage());
-    } catch (IOException e) {
-      LOG.error(e.getMessage());
-    } catch (ParserConfigurationException e) {
-      LOG.error(e.getMessage());
-    } catch (Throwable e) {
+    } catch (SAXException | IOException | ParserConfigurationException e) {
       LOG.error(e.getMessage());
     }
     return doc;

--- a/redpen-core/src/main/java/org/bigram/docvalidator/DocumentValidatorException.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/DocumentValidatorException.java
@@ -44,7 +44,7 @@ public class DocumentValidatorException extends Exception {
    * @param message error message
    * @param cause   error cause
    */
-  public DocumentValidatorException(String message, Throwable cause) {
+  public DocumentValidatorException(String message, Exception cause) {
     super(message, cause);
   }
 }

--- a/redpen-core/src/main/java/org/bigram/docvalidator/formatter/XMLFormatter.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/formatter/XMLFormatter.java
@@ -118,12 +118,7 @@ public class XMLFormatter implements Formatter {
 
   private Transformer createTransformer() {
     TransformerFactory tf;
-    try {
-      tf = TransformerFactory.newInstance();
-    } catch (Throwable e) {
-      LOG.error(e.getMessage());
-      return null;
-    }
+    tf = TransformerFactory.newInstance();
 
     Transformer transformer;
     try {

--- a/redpen-core/src/main/java/org/bigram/docvalidator/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/org/bigram/docvalidator/parser/markdown/ToFileContentSerializer.java
@@ -135,7 +135,7 @@ public class ToFileContentSerializer implements Visitor {
     try {
       checkArgNotNull(astRoot, "astRoot");
       astRoot.accept(this);
-    } catch (Throwable e) {
+    } catch (NullPointerException e) {
       LOG.error("Fail to traverse RootNode.");
       throw new DocumentValidatorException("Fail to traverse RootNode.", e);
     }


### PR DESCRIPTION
stop using Throwable

Catching "Throwable" is generally discouraged. It'll make it difficult to detect the root cause of Errors.
Additionally, applied multi-catch syntax introduced in Java 7.
