### PR TITLE
Fix runtime failure of redpen server

### DIFF
--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -81,7 +82,7 @@
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <includeGroupIds>org.eclipse.jetty, commons-cli</includeGroupIds>
+              <includeGroupIds>org.eclipse.jetty, commons-cli, javax.servlet</includeGroupIds>
               <includeScope>provided</includeScope>
               <!-- remove some files in order to decrease size -->
               <excludes>*, about_files/*, META-INF/*</excludes>


### PR DESCRIPTION
RedPen server failed with the following log. This patch fixes the runtime error.

```
redpen/redpen-server/target$ java -jar redpen-server.war
Exception in thread "main" java.lang.NoClassDefFoundError: javax/servlet/ServletContext
    at java.lang.Class.getDeclaredMethods0(Native Method)
    at java.lang.Class.privateGetDeclaredMethods(Class.java:2688)
    at java.lang.Class.getMethod0(Class.java:2937)
    at java.lang.Class.getMethod(Class.java:1771)
    at sun.launcher.LauncherHelper.validateMainClass(LauncherHelper.java:544)
    at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:526)
Caused by: java.lang.ClassNotFoundException: javax.servlet.ServletContext
     at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 6 more
```
