### PR TITLE
stop using application attribute It turns out that use of application attribute was actually unnecessary. It is not type-safe.

### DIFF
--- a/redpen-server/src/main/java/org/bigram/docvalidator/server/DocumentValidatorInitializer.java
+++ b/redpen-server/src/main/java/org/bigram/docvalidator/server/DocumentValidatorInitializer.java
@@ -39,12 +39,9 @@ public class DocumentValidatorInitializer implements ServletContextListener {
   public void contextInitialized(ServletContextEvent servletContextEvent) {
     log.info("Starting Document Validator Server.");
     String configPath = System.getProperty("redpen.conf.path");
-    // if redpen.conf.path is not set via system property, look into ServletContext attribute, then fallback to web.xml's context-param.
+    // if redpen.conf.path is not set via system property, fallback to web.xml's context-param.
     if (configPath == null) {
-      configPath = (String) servletContextEvent.getServletContext().getAttribute("redpen.conf.path");
-      if (configPath == null) {
-        configPath = servletContextEvent.getServletContext().getInitParameter("redpen.conf.path");
-      }
+      configPath = servletContextEvent.getServletContext().getInitParameter("redpen.conf.path");
       if (configPath == null) {
         throw new ExceptionInInitializerError("redpen.conf.path not specified in web.xml");
       }

--- a/redpen-server/src/test/java/org/bigram/docvalidator/server/api/DocumentValidateResourceTest.java
+++ b/redpen-server/src/test/java/org/bigram/docvalidator/server/api/DocumentValidateResourceTest.java
@@ -44,7 +44,7 @@ public class DocumentValidateResourceTest extends MockServletInvocationTest {
         constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
     request.setContent(("textarea=foobar").getBytes());
     MockServletContext context = new MockServletContext();
-    context.setAttribute("redpen.conf.path", "conf/dv-conf.xml");
+    context.addInitParameter("redpen.conf.path", "conf/dv-conf.xml");
     listner.contextInitialized(new ServletContextEvent(context));
     MockHttpServletResponse response = invoke(request);
 
@@ -58,7 +58,7 @@ public class DocumentValidateResourceTest extends MockServletInvocationTest {
         constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
     request.setContent(("textarea=foobar.foobar").getBytes()); //NOTE: need space between periods.
     MockServletContext context = new MockServletContext();
-    context.setAttribute("redpen.conf.path", "conf/dv-conf.xml");
+    context.addInitParameter("redpen.conf.path", "conf/dv-conf.xml");
     listner.contextInitialized(new ServletContextEvent(context));
     MockHttpServletResponse response = invoke(request);
 
@@ -73,7 +73,7 @@ public class DocumentValidateResourceTest extends MockServletInvocationTest {
         constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
     request.setContent(("").getBytes()); //NOTE: need space between periods.
     MockServletContext context = new MockServletContext();
-    context.setAttribute("redpen.conf.path", "conf/dv-conf.xml");
+    context.addInitParameter("redpen.conf.path", "conf/dv-conf.xml");
     listner.contextInitialized(new ServletContextEvent(context));
     MockHttpServletResponse response = invoke(request);
 
@@ -85,7 +85,7 @@ public class DocumentValidateResourceTest extends MockServletInvocationTest {
         constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
     request.setContent(("textarea=").getBytes()); //NOTE: need space between periods.
     MockServletContext context = new MockServletContext();
-    context.setAttribute("redpen.conf.path", "conf/dv-conf.xml");
+    context.addInitParameter("redpen.conf.path", "conf/dv-conf.xml");
     listner.contextInitialized(new ServletContextEvent(context));
     MockHttpServletResponse response = invoke(request);
 


### PR DESCRIPTION
stop using application attribute
It turns out that use of application attribute was actually unnecessary. It is not type-safe.
