### PR TITLE
Fix #157. Add coveralls and JaCoCo maven plugin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,13 @@ language: java
 jdk:
   - oraclejdk8
 
+env:
+  global:
+    - secure:"Dupdb/HgNXKu8kOo7/RcpMCAyEZA8hLw77nVPTxXUo39UUI/ipnbUfRHamiWC2/MCqTEHu+1eReCmuFj2ULk4g+vi/8VYjrmX1TiHwikIFEAGrRRK0VkuWegqloYtXuxa7gtuQ96PWjqJ48op/WYyYvKiH0cFOMHsZOt5cl9PL4="
+
 script:
   - sh ./run_test.sh
+
+after_success:
+  - cd redpen-core/
+  - mvn clean test -DrepoToken=${REPO_TOKEN} jacoco:report coveralls:jacoco

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/recruit-tech/redpen.svg?branch=master)](https://travis-ci.org/recruit-tech/redpen)
+[![Coverage Status](https://coveralls.io/repos/recruit-tech/redpen/badge.png)](https://coveralls.io/r/recruit-tech/redpen)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/recruit-tech/redpen?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 RedPen
 =======

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -79,7 +79,7 @@
                     <excludes>
                         <exclude>**/**$**</exclude>
                     </excludes>
-                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <argLine>${argLine} -Dfile.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -94,6 +94,24 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>2.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.1.201405082137</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fix #157 .
- Add coveralls and JaCoCo maven plugin.
  - JaCoCo can only test single module...So I apply it to `redpen-core`.
- Add travis and coveralls badge to README.md.
