### PR TITLE
forcibly fallback to English resources when specifying non-Japanese locale

### DIFF
--- a/redpen-core/src/test/java/cc/redpen/RedPenTest.java
+++ b/redpen-core/src/test/java/cc/redpen/RedPenTest.java
@@ -21,9 +21,11 @@ import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.distributor.FakeResultDistributor;
 import cc.redpen.model.DocumentCollection;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -31,6 +33,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.containsString;
 
 public class RedPenTest {
+    @Before
+    public void setUp() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void testEmptyValidator() throws RedPenException {

--- a/redpen-core/src/test/java/cc/redpen/validator/ValidationErrorMessageTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/ValidationErrorMessageTest.java
@@ -11,7 +11,10 @@ class ValidationErrorMessageTest extends Validator<Sentence> {
     @Override
     public List<ValidationError> validate(Sentence sentence) {
         List<ValidationError> errors = new ArrayList<>();
-        errors.add(createValidationError(sentence, 1, 2, 3, "string"));
+        errors.add(createValidationError(sentence, 1, 2, 3, "sentence"));
+        errors.add(createValidationError("withKey", sentence, "sentence"));
+        errors.add(createValidationError(10, 1, 2, 3, "lineNumber"));
+        errors.add(createValidationError("withKey", 10, "lineNumber"));
         return errors;
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/ValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/ValidatorTest.java
@@ -32,12 +32,19 @@ public class ValidatorTest {
     public void testValidationErrorCreation() throws RedPenException {
         ValidationErrorMessageTest validationErrorMessageTest = new ValidationErrorMessageTest();
         validationErrorMessageTest.preInit(null, null);
+        validationErrorMessageTest.setLocale(Locale.ENGLISH);
         List<ValidationError> validationErrors = validationErrorMessageTest.validate(new Sentence("sentence", 1));
-        assertEquals("error str:string 1:1 2:2 3:3", validationErrors.get(0).getMessage());
+        assertEquals("error str:sentence 1:1 2:2 3:3", validationErrors.get(0).getMessage());
+        assertEquals("with Key :sentence", validationErrors.get(1).getMessage());
+        assertEquals("error str:lineNumber 1:1 2:2 3:3", validationErrors.get(2).getMessage());
+        assertEquals("with Key :lineNumber", validationErrors.get(3).getMessage());
 
         validationErrorMessageTest.setLocale(Locale.JAPAN);
         validationErrors = validationErrorMessageTest.validate(new Sentence("sentence", 1));
-        assertEquals("エラー ストリング:string 1:1 2:2 3:3", validationErrors.get(0).getMessage());
+        assertEquals("エラー ストリング:sentence 1:1 2:2 3:3", validationErrors.get(0).getMessage());
+        assertEquals("キー指定 :sentence", validationErrors.get(1).getMessage());
+        assertEquals("エラー ストリング:lineNumber 1:1 2:2 3:3", validationErrors.get(2).getMessage());
+        assertEquals("キー指定 :lineNumber", validationErrors.get(3).getMessage());
 
     }
 }

--- a/redpen-core/src/test/resources/cc/redpen/validator/error-messages.properties
+++ b/redpen-core/src/test/resources/cc/redpen/validator/error-messages.properties
@@ -1,1 +1,2 @@
 ValidationErrorMessageTest=error str\:{3} 1\:{0} 2\:{1} 3\:{2}
+ValidationErrorMessageTest.withKey=with Key \:{0}

--- a/redpen-core/src/test/resources/cc/redpen/validator/error-messages_ja.properties
+++ b/redpen-core/src/test/resources/cc/redpen/validator/error-messages_ja.properties
@@ -1,1 +1,3 @@
 ValidationErrorMessageTest=\u30A8\u30E9\u30FC \u30B9\u30C8\u30EA\u30F3\u30B0\:{3} 1\:{0} 2\:{1} 3\:{2}
+ValidationErrorMessageTest.withKey=\u30AD\u30FC\u6307\u5B9A \:{0}
+ValidationErrorMessageTest.withLineNumber=


### PR DESCRIPTION
forcibly fallback to English resources when specifying non-Japanese locale
introduce ValidationError factory method with line number
