### PR TITLE
Rename Parser to DocumentParser

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -22,13 +22,10 @@ import cc.redpen.distributor.ResultDistributor;
 import cc.redpen.distributor.ResultDistributorFactory;
 import cc.redpen.formatter.Formatter;
 import cc.redpen.model.DocumentCollection;
-import cc.redpen.parser.Parser;
+import cc.redpen.parser.DocumentParser;
 import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Class containing main method called from command line.
@@ -83,7 +80,7 @@ public final class Main {
         String inputFormat = "plain";
         String configFileName = "";
         String resultFormat = "plain";
-        Parser.Type parserType;
+        DocumentParser.Type parserType;
         Formatter.Type outputFormat;
 
         if (commandLine.hasOption("h")) {
@@ -113,7 +110,7 @@ public final class Main {
             System.exit(-1);
         }
 
-        parserType = Parser.Type.valueOf(inputFormat.toUpperCase());
+        parserType = DocumentParser.Type.valueOf(inputFormat.toUpperCase());
         outputFormat = Formatter.Type.valueOf(resultFormat.toUpperCase());
 
         DocumentCollection documentCollection =

--- a/redpen-core/src/main/java/cc/redpen/DocumentGenerator.java
+++ b/redpen-core/src/main/java/cc/redpen/DocumentGenerator.java
@@ -19,8 +19,8 @@ package cc.redpen;
 
 import cc.redpen.config.Configuration;
 import cc.redpen.model.DocumentCollection;
+import cc.redpen.parser.DocumentParser;
 import cc.redpen.parser.DocumentParserFactory;
-import cc.redpen.parser.Parser;
 
 /**
  * Generate DocumentCollection object loading input file.
@@ -40,10 +40,10 @@ public final class DocumentGenerator {
      */
     static DocumentCollection generate(String[] inputFileNames,
                                        Configuration configuration,
-                                       Parser.Type format) throws RedPenException {
+                                       DocumentParser.Type format) throws RedPenException {
         DocumentCollection.Builder documentBuilder =
                 new DocumentCollection.Builder(configuration.getSymbolTable().getLang());
-        Parser parser = DocumentParserFactory.generate(format,
+        DocumentParser parser = DocumentParserFactory.generate(format,
                 configuration, documentBuilder);
 
         for (String inputFileName : inputFileNames) {

--- a/redpen-core/src/main/java/cc/redpen/parser/BaseDocumentParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/BaseDocumentParser.java
@@ -34,7 +34,7 @@ import java.util.List;
  * Abstract Parser class containing common procedures to
  * implements the concrete Parser classes.
  */
-public abstract class BaseDocumentParser implements Parser {
+public abstract class BaseDocumentParser implements DocumentParser {
     private static final Logger LOG = LoggerFactory.getLogger(
             BaseDocumentParser.class);
     protected DocumentCollection.Builder builder;

--- a/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
@@ -25,9 +25,9 @@ import cc.redpen.model.DocumentCollection;
 import java.io.InputStream;
 
 /**
- * Parser generates Document from input.
+ * DocumentParser generates Document from input.
  */
-public interface Parser {
+public interface DocumentParser {
     /**
      * Given input stream, return Document instance from a stream.
      *

--- a/redpen-core/src/main/java/cc/redpen/parser/DocumentParserFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/DocumentParserFactory.java
@@ -38,11 +38,11 @@ public final class DocumentParserFactory {
      * @return Parser implementation object
      * @throws cc.redpen.RedPenException when failed to generate Parser instance or no specified parser implementation.
      */
-    public static Parser generate(Parser.Type parserType,
+    public static DocumentParser generate(DocumentParser.Type parserType,
                                   Configuration configuration,
                                   DocumentCollection.Builder documentBuilder)
             throws RedPenException {
-        Parser docparser;
+        DocumentParser docparser;
         switch (parserType) {
             case PLAIN:
                 docparser = new PlainTextParser();

--- a/redpen-core/src/test/java/cc/redpen/SampleDocumentGenerator.java
+++ b/redpen-core/src/test/java/cc/redpen/SampleDocumentGenerator.java
@@ -19,8 +19,8 @@ package cc.redpen;
 
 import cc.redpen.config.Configuration;
 import cc.redpen.model.DocumentCollection;
+import cc.redpen.parser.DocumentParser;
 import cc.redpen.parser.DocumentParserFactory;
-import cc.redpen.parser.Parser;
 import org.apache.commons.io.IOUtils;
 
 import java.io.InputStream;
@@ -41,11 +41,11 @@ public class SampleDocumentGenerator {
      * @return DocumentCollection object
      */
     public static DocumentCollection generateOneFileDocument(String docString,
-                                                             Parser.Type type) throws RedPenException {
+                                                             DocumentParser.Type type) throws RedPenException {
         Configuration configuration = new Configuration.Builder()
                 .setSymbolTable("en").build();
         DocumentCollection.Builder builder = new DocumentCollection.Builder();
-        Parser parser = DocumentParserFactory.generate(type, configuration, builder);
+        DocumentParser parser = DocumentParserFactory.generate(type, configuration, builder);
         InputStream stream = IOUtils.toInputStream(docString);
         parser.generateDocument(stream);
         return builder.build();

--- a/redpen-core/src/test/java/cc/redpen/SampleDocumentGeneratorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/SampleDocumentGeneratorTest.java
@@ -20,7 +20,7 @@ package cc.redpen;
 import cc.redpen.model.DocumentCollection;
 import org.junit.Test;
 
-import static cc.redpen.parser.Parser.Type.*;
+import static cc.redpen.parser.DocumentParser.Type.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/redpen-core/src/test/java/cc/redpen/parser/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/MarkdownParserTest.java
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
-import static cc.redpen.parser.Parser.Type.MARKDOWN;
+import static cc.redpen.parser.DocumentParser.Type.MARKDOWN;
 import static org.junit.Assert.*;
 
 public class MarkdownParserTest {
@@ -39,14 +39,14 @@ public class MarkdownParserTest {
 
     @Test(expected = RedPenException.class)
     public void testNullDocument() throws Exception {
-        Parser parser = loadParser(new Configuration.Builder().build());
+        DocumentParser parser = loadParser(new Configuration.Builder().build());
         InputStream is = null;
         parser.generateDocument(is);
     }
 
     @Test(expected = RedPenException.class)
     public void testNullFileName() throws Exception {
-        Parser parser = loadParser(new Configuration.Builder().build());
+        DocumentParser parser = loadParser(new Configuration.Builder().build());
         String fileName = null;
         parser.generateDocument(fileName);
     }
@@ -460,8 +460,8 @@ public class MarkdownParserTest {
     }
 
 
-    private Parser loadParser(Configuration configuration) {
-        Parser parser = null;
+    private DocumentParser loadParser(Configuration configuration) {
+        DocumentParser parser = null;
         try {
             parser = DocumentParserFactory.generate(MARKDOWN, configuration,
                     new DocumentCollection.Builder());
@@ -482,7 +482,7 @@ public class MarkdownParserTest {
             fail();
         }
 
-        Parser parser = loadParser(config);
+        DocumentParser parser = loadParser(config);
 
         try {
             return parser.generateDocument(inputDocumentStream);
@@ -494,7 +494,7 @@ public class MarkdownParserTest {
 
     private Document createFileContent(
             String inputDocumentString) {
-        Parser parser = loadParser(new Configuration.Builder().build());
+        DocumentParser parser = loadParser(new Configuration.Builder().build());
         InputStream is;
         try {
             is = new ByteArrayInputStream(inputDocumentString.getBytes("utf-8"));

--- a/redpen-core/src/test/java/cc/redpen/parser/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/PlainTextParserTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.fail;
 
 public class PlainTextParserTest {
 
-    private Parser parser = null;
+    private DocumentParser parser = null;
 
     private List<Paragraph> extractParagraphs(Section section) {
         List<Paragraph> paragraphs = new ArrayList<>();
@@ -80,7 +80,7 @@ public class PlainTextParserTest {
                         new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
                 .build();
         try {
-            parser = DocumentParserFactory.generate(Parser.Type.PLAIN, configuration, new DocumentCollection.Builder());
+            parser = DocumentParserFactory.generate(DocumentParser.Type.PLAIN, configuration, new DocumentCollection.Builder());
         } catch (RedPenException e1) {
             e1.printStackTrace();
             fail();
@@ -176,7 +176,7 @@ public class PlainTextParserTest {
 
     @Test(expected = RedPenException.class)
     public void testNullInitialize() throws Exception {
-        DocumentParserFactory.generate(Parser.Type.PLAIN, null,
+        DocumentParserFactory.generate(DocumentParser.Type.PLAIN, null,
                 new DocumentCollection.Builder());
     }
 

--- a/redpen-core/src/test/java/cc/redpen/parser/WikiParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/WikiParserTest.java
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
-import static cc.redpen.parser.Parser.Type.WIKI;
+import static cc.redpen.parser.DocumentParser.Type.WIKI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -557,8 +557,8 @@ public class WikiParserTest {
         assertEquals(2, firstParagraph.getNumberOfSentences());
     }
 
-    private Parser loadParser(Configuration configuration) {
-        Parser parser = null;
+    private DocumentParser loadParser(Configuration configuration) {
+        DocumentParser parser = null;
         try {
             parser = DocumentParserFactory.generate(WIKI, configuration,
                     new DocumentCollection.Builder());
@@ -579,7 +579,7 @@ public class WikiParserTest {
             fail();
         }
 
-        Parser parser = loadParser(conf);
+        DocumentParser parser = loadParser(conf);
         try {
             return parser.generateDocument(inputDocumentStream);
         } catch (RedPenException e) {
@@ -592,7 +592,7 @@ public class WikiParserTest {
             String inputDocumentString) {
         ValidatorConfiguration conf = new ValidatorConfiguration("dummy");
         Configuration.Builder builder = new Configuration.Builder();
-        Parser parser = loadParser(builder.build());
+        DocumentParser parser = loadParser(builder.build());
         InputStream is;
         try {
             is = new ByteArrayInputStream(inputDocumentString.getBytes("utf-8"));

--- a/redpen-server/src/main/java/cc/redpen/server/api/DocumentValidateResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/DocumentValidateResource.java
@@ -22,8 +22,8 @@ import cc.redpen.RedPen;
 import cc.redpen.RedPenException;
 import cc.redpen.model.Document;
 import cc.redpen.model.DocumentCollection;
+import cc.redpen.parser.DocumentParser;
 import cc.redpen.parser.DocumentParserFactory;
-import cc.redpen.parser.Parser;
 import cc.redpen.validator.ValidationError;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -106,8 +106,8 @@ public class DocumentValidateResource {
 
         json.put("document", document);
 
-        Parser parser = DocumentParserFactory.generate(
-                Parser.Type.PLAIN, server.getConfiguration(), new DocumentCollection.Builder());
+        DocumentParser parser = DocumentParserFactory.generate(
+                DocumentParser.Type.PLAIN, server.getConfiguration(), new DocumentCollection.Builder());
         Document fileContent = parser.generateDocument(new
                 ByteArrayInputStream(document.getBytes("UTF-8")));
 


### PR DESCRIPTION
- Rename Parser to DocumentParser to avoid the naming ambiguity when redpen supports linguistics parsers in the future.
