### PR TITLE
Remove hankaku space from invalid symbol of default Japanese white space

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
+++ b/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
@@ -209,7 +209,7 @@ public final class SymbolTable implements Serializable {
 
         JAPANESE_SYMBOLS = initializeSymbols(
                 // Common symbols
-                new Symbol(SPACE, '　', " ")
+                new Symbol(SPACE, '　', "")
                 , new Symbol(EXCLAMATION_MARK, '！', "!")
                 , new Symbol(NUMBER_SIGN, '＃', "#")
                 , new Symbol(DOLLAR_SIGN, '$', "＄")


### PR DESCRIPTION
I removed ASCII white space from default invalid symbol of Japanese white space, since white space is commonly used between alphabetical words in Japanese text.
