### PR TITLE
enable CLI tests separate main logic for the better testability

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -52,11 +52,11 @@ public final class Main {
      * @param args arguments
      * @throws RedPenException
      */
-    public static void main(String[] args) throws RedPenException {
+    public static void main(String... args) throws RedPenException {
         System.exit(run(args));
     }
 
-    public static int run(String[] args) throws RedPenException {
+    public static int run(String... args) throws RedPenException {
         Options options = new Options();
         options.addOption("h", "help", false, "Displays this help information and exits");
 

--- a/redpen-cli/src/test/java/cc/redpen/MainTest.java
+++ b/redpen-cli/src/test/java/cc/redpen/MainTest.java
@@ -19,6 +19,8 @@ package cc.redpen;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class MainTest {
 
     @Test
@@ -32,12 +34,12 @@ public class MainTest {
 
     @Test
     public void testHelp() throws RedPenException {
-        Main.run(new String[] { "-h" });
+        assertEquals(0, Main.run("-h"));
     }
 
     @Test
     public void testVersion() throws RedPenException {
-        Main.run(new String[] { "-v" });
+        assertEquals(0, Main.run("-v"));
     }
 
 }


### PR DESCRIPTION
enable CLI tests
separate main logic for the better testability

testMain() fails with StringIndexOutOfBoundsException. need to be reviewed.
