### PR TITLE
Increase redpen command (cli) version to 1.0.1

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -46,7 +46,7 @@ public final class Main {
 
     private static final String PROGRAM = "redpen-cli";
 
-    private static final String VERSION = "1.0";
+    private static final String VERSION = "1.0.1";
 
     private static final int EDEFAULT_LIMIT = 1;
 


### PR DESCRIPTION
After the release 1.0, two pull requests (#366, #367) have been merged. The pull requests contain the changes of cli output format.

In order to tell the users or tools that depend on the redpen command the changes, I have assigned the new version 1.0.1 for the changes.
