### PR TITLE
Prepare for using Kuromoji being from Maven Central

### DIFF
--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -118,9 +118,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.atilika.kuromoji</groupId>
-            <artifactId>kuromoji</artifactId>
-            <version>0.7.7</version>
+            <groupId>com.atilika.kuromoji</groupId>
+            <artifactId>kuromoji-ipadic</artifactId>
+            <version>0.9.0</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
@@ -176,8 +176,8 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>Atilika Open Source repository</id>
-            <url>http://www.atilika.org/nexus/content/repositories/atilika</url>
+            <id>sonatype-nexus-staging</id>
+            <url>https://oss.sonatype.org/content/groups/staging/</url>
         </repository>
     </repositories>
 </project>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -177,7 +177,7 @@
     <repositories>
         <repository>
             <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/content/groups/staging/</url>
+            <url>https://oss.sonatype.org/content/repositories/comatilika-1002/</url>
         </repository>
     </repositories>
 </project>

--- a/redpen-core/src/main/java/cc/redpen/tokenizer/JapaneseTokenizer.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/JapaneseTokenizer.java
@@ -17,8 +17,8 @@
  */
 package cc.redpen.tokenizer;
 
-import org.atilika.kuromoji.Token;
-import org.atilika.kuromoji.Tokenizer;
+import com.atilika.kuromoji.ipadic.Token;
+import com.atilika.kuromoji.ipadic.Tokenizer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,14 +29,14 @@ public class JapaneseTokenizer implements RedPenTokenizer {
     private Tokenizer tokenizer;
 
     public JapaneseTokenizer() {
-        this.tokenizer = Tokenizer.builder().build();
+        this.tokenizer = new Tokenizer();
     }
 
     @Override
     public List<TokenElement> tokenize(String content) {
         List<TokenElement> tokens = new ArrayList<>();
         for (Token token : tokenizer.tokenize(content)) {
-            tokens.add(new TokenElement(token.getSurfaceForm(), Arrays.asList(token.getAllFeaturesArray()), token.getPosition()));
+            tokens.add(new TokenElement(token.getSurface(), Arrays.asList(token.getAllFeaturesArray()), token.getPosition()));
         }
         return tokens;
     }


### PR DESCRIPTION
We are planning on publishing Kuromoji to Maven Central soon.  As part of this, it would be great to test it in a few projects before we release it.  This pull-requests contains changes that uses `kuromoji-ipadic` from the release candidate from Sonatype's staging repository.