### PR TITLE
Support Portable Object (.po) parser

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -65,7 +65,7 @@ public final class Main {
         options.addOption("h", "help", false, "Displays this help information and exits");
 
         options.addOption(OptionBuilder.withLongOpt("format")
-                .withDescription("Input file format (markdown,plain,wiki,asciidoc,latex)")
+                .withDescription("Input file format (markdown,plain,wiki,asciidoc,latex,po)")
                 .hasArg()
                 .withArgName("FORMAT")
                 .create("f"));

--- a/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
@@ -88,6 +88,7 @@ public interface DocumentParser {
     public static final DocumentParser MARKDOWN = new MarkdownParser();
     public static final DocumentParser LATEX = new LaTeXParser();
     public static final DocumentParser ASCIIDOC = new AsciiDocParser();
+    public static final DocumentParser PO = new PortableObjectParser();
 
     public static final Map<String, DocumentParser> PARSER_MAP = Collections.unmodifiableMap(
             new HashMap<String, DocumentParser>() {
@@ -97,6 +98,7 @@ public interface DocumentParser {
                     put("MARKDOWN", MARKDOWN);
                     put("LATEX", LATEX);
                     put("ASCIIDOC", ASCIIDOC);
+                    put("PO", PO);
                 }
             });
 

--- a/redpen-core/src/main/java/cc/redpen/parser/PortableObjectParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PortableObjectParser.java
@@ -87,8 +87,6 @@ final class PortableObjectParser extends BaseDocumentParser {
         boolean isMsgidBlock = false;
         BufferedReader br = createReader(inputStream);
 
-        documentBuilder.addParagraph();
-
         try {
             while ((line = br.readLine()) != null) {
                 if (check(COMMENT_PATTERN, line)) {
@@ -110,8 +108,8 @@ final class PortableObjectParser extends BaseDocumentParser {
                     }
                 } else if (line.equals("")) {
                     if (msgid.length() > 0) {
-                        this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
                         documentBuilder.addParagraph();
+                        this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
                     }
                     msgid.delete(0, msgid.length());
                     msgstr.delete(0, msgstr.length());
@@ -119,8 +117,8 @@ final class PortableObjectParser extends BaseDocumentParser {
                 lineNum++;
             }
             if (msgstr.length() > 0) {
-                this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
                 documentBuilder.addParagraph();
+                this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
             }
         } catch (IOException e) {
             throw new RedPenException(e);

--- a/redpen-core/src/main/java/cc/redpen/parser/PortableObjectParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PortableObjectParser.java
@@ -1,0 +1,198 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen.parser;
+
+import cc.redpen.RedPenException;
+import cc.redpen.model.Document;
+import cc.redpen.model.Section;
+import cc.redpen.model.Sentence;
+import cc.redpen.tokenizer.RedPenTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parser for Portable Object format (well known as .po)
+ */
+final class PortableObjectParser extends BaseDocumentParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PortableObjectParser.class);
+
+    private static final Pattern MSGID_PATTERN
+            = Pattern.compile("^msgid \".*");
+    private static final Pattern MSGSTR_PATTERN
+            = Pattern.compile("^msgstr \".*");
+    private static final Pattern MSGBODY_PATTERN
+            = Pattern.compile("^\".+\"$");
+    private static final Pattern COMMENT_PATTERN
+            = Pattern.compile("^#.*$");
+
+    PortableObjectParser() {
+        super();
+    }
+
+    @Override
+    public String toString() {
+        return "PortableObjectParser{}";
+    }
+
+    private static boolean check(Pattern p, String target) {
+        Matcher m = p.matcher(target);
+        if (m.matches()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public Document parse(InputStream inputStream, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer)
+            throws RedPenException {
+        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        fileName.ifPresent(documentBuilder::setFileName);
+
+        // add dummy section
+        List<Sentence> headers = new ArrayList<>();
+        headers.add(new Sentence("", 0));
+        documentBuilder.addSection(0, headers);
+
+        StringBuilder msgid = new StringBuilder();
+        StringBuilder msgstr = new StringBuilder();
+        String line;
+        int lineNum = 1;
+        int lineNumMsgstr = 1;
+        boolean isMsgidBlock = false;
+        BufferedReader br = createReader(inputStream);
+
+        documentBuilder.addParagraph();
+
+        try {
+            while ((line = br.readLine()) != null) {
+                if (check(COMMENT_PATTERN, line)) {
+                    // do nothing
+                } else if (check(MSGID_PATTERN, line)) {
+                    msgid.delete(0, msgid.length());
+                    msgid.append(line.substring(7, line.length() - 1));
+                    isMsgidBlock = true;
+                } else if (check(MSGSTR_PATTERN, line)) {
+                    msgstr.delete(0, msgstr.length());
+                    msgstr.append(line.substring(8, line.length() - 1));
+                    isMsgidBlock = false;
+                    lineNumMsgstr = lineNum;
+                } else if (check(MSGBODY_PATTERN, line)) {
+                    if (isMsgidBlock) {
+                        msgid.append(line.substring(1, line.length() - 1));
+                    } else {
+                        msgstr.append(line.substring(1, line.length() - 1));
+                    }
+                } else if (line.equals("")) {
+                    if (msgid.length() > 0) {
+                        this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
+                        documentBuilder.addParagraph();
+                    }
+                    msgid.delete(0, msgid.length());
+                    msgstr.delete(0, msgstr.length());
+                }
+                lineNum++;
+            }
+            if (msgstr.length() > 0) {
+                this.extractSentences(lineNumMsgstr, msgstr.toString(), sentenceExtractor, documentBuilder);
+                documentBuilder.addParagraph();
+            }
+        } catch (IOException e) {
+            throw new RedPenException(e);
+        }
+
+        return documentBuilder.build();
+    }
+
+    /* Extract sentences from a paragraph */
+    private void extractSentences(int lineNum, String paragraphText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+        int periodPosition = sentenceExtractor.getSentenceEndPosition(paragraphText);
+        LineOffset lineOffset = new LineOffset(lineNum, 0);
+        if (periodPosition == -1) {
+            addSentence(lineOffset, paragraphText, sentenceExtractor, builder);
+        } else {
+            while (true) {
+                lineOffset = addSentence(lineOffset, paragraphText.substring(0, periodPosition + 1), sentenceExtractor, builder);
+                paragraphText = paragraphText.substring(periodPosition + 1, paragraphText.length());
+                periodPosition = sentenceExtractor.getSentenceEndPosition(paragraphText);
+                if (periodPosition == -1) {
+                    if (!paragraphText.isEmpty()) {
+                        addSentence(lineOffset, paragraphText, sentenceExtractor, builder);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    /* Add a sentence with offsets */
+    public static LineOffset addSentence(LineOffset lineOffset, String rawSentenceText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+
+        int lineNum = lineOffset.lineNum;
+        int offset = lineOffset.offset;
+
+        int sentenceStartLineNum = lineNum;
+        int sentenceStartLineOffset = offset;
+
+        List<LineOffset> offsetMap = new ArrayList<>();
+        String normalizedSentence = "";
+        int i;
+        // skip leading line breaks to find the start line of the sentence
+        for (i = 0; i < rawSentenceText.length(); i++) {
+            char ch = rawSentenceText.charAt(i);
+            if (ch == '\n') {
+                sentenceStartLineNum++;
+                lineNum++;
+                sentenceStartLineOffset = 0;
+                offset = 0;
+            } else {
+                break;
+            }
+        }
+        for (; i < rawSentenceText.length(); i++) {
+            char ch = rawSentenceText.charAt(i);
+            if (ch == '\n') {
+                if (!sentenceExtractor.getBrokenLineSeparator().isEmpty()) {
+                    offsetMap.add(new LineOffset(lineNum, offset));
+                    normalizedSentence += sentenceExtractor.getBrokenLineSeparator();
+                }
+                lineNum++;
+                offset = 0;
+            } else {
+                normalizedSentence += ch;
+                offsetMap.add(new LineOffset(lineNum, offset));
+                offset++;
+            }
+        }
+        Sentence sentence = new Sentence(normalizedSentence, sentenceStartLineNum, sentenceStartLineOffset);
+        sentence.setOffsetMap(offsetMap);
+        builder.addSentence(sentence);
+
+        return new LineOffset(lineNum, offset);
+    }
+}

--- a/redpen-core/src/test/java/cc/redpen/PortableObjectParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PortableObjectParserTest.java
@@ -131,4 +131,26 @@ public class PortableObjectParserTest {
         assertEquals(6, section.getParagraph(1).getSentence(0).getLineNumber());
         assertEquals("RedPenは文章の校正ツールです。", section.getParagraph(1).getSentence(0).getContent());
     }
+
+    @Test
+    public void testExtractedMultipleSentences() {
+        String sampleText = "";
+        sampleText += "msgid \"\"\n";
+        sampleText += "\"RedPen is a proofreading tool.\"\n";
+        sampleText += "\"It helps programmers who write technical documents \"\n";
+        sampleText += "\"that need to adhere to a writing standard.\"\n";
+        sampleText += "msgstr \"\"\n";
+        sampleText += "\"RedPenは文章の校正ツールです。プログラマが技術文書を規約にしたがって記述するのを支援します。\"\n";
+
+        Document doc = generateDocument(sampleText);
+        Section section = doc.getLastSection();
+        assertEquals(2, getTotalSentenceCount(section));
+        assertEquals(1, extractParagraphs(section).size());
+
+        assertEquals(2, section.getParagraph(0).getNumberOfSentences());
+        assertEquals(5, section.getParagraph(0).getSentence(0).getLineNumber());
+        assertEquals("RedPenは文章の校正ツールです。", section.getParagraph(0).getSentence(0).getContent());
+        assertEquals("プログラマが技術文書を規約にしたがって記述するのを支援します。", section.getParagraph(0).getSentence(1).getContent());
+    }
+
 }

--- a/redpen-core/src/test/java/cc/redpen/PortableObjectParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PortableObjectParserTest.java
@@ -1,0 +1,134 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen;
+
+import cc.redpen.config.Configuration;
+import cc.redpen.config.ValidatorConfiguration;
+import cc.redpen.model.Document;
+import cc.redpen.model.Paragraph;
+import cc.redpen.model.Section;
+import cc.redpen.model.Sentence;
+import cc.redpen.parser.DocumentParser;
+import cc.redpen.parser.LineOffset;
+import cc.redpen.parser.SentenceExtractor;
+import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.validator.ValidationError;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PortableObjectParserTest {
+
+    private DocumentParser parser = null;
+
+    private List<Paragraph> extractParagraphs(Section section) {
+        List<Paragraph> paragraphs = new ArrayList<>();
+        for (Paragraph paragraph1 : section.getParagraphs()) {
+            paragraphs.add(paragraph1);
+        }
+        return paragraphs;
+    }
+
+    private int getTotalSentenceCount(Section section) {
+        int lineNum = 0;
+
+        for (Paragraph paragraph : section.getParagraphs()) {
+            lineNum += paragraph.getNumberOfSentences();
+        }
+        return lineNum;
+    }
+
+    private Document generateDocument(String sampleText) {
+        return generateDocument(sampleText, "ja");
+    }
+
+    private Document generateDocument(String sampleText, String lang) {
+        Document doc = null;
+        Configuration configuration = new Configuration.ConfigurationBuilder().setLanguage(lang).build();
+
+        try {
+            doc = parser.parse(sampleText, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
+        } catch (RedPenException e) {
+            fail();
+        }
+        return doc;
+    }
+
+    @Before
+    public void setup() {
+        Configuration configuration = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(
+                        new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
+                .build();
+        parser = DocumentParser.PO;
+    }
+
+    @Test
+    public void testEmptyMsgidIsIgnored() {
+        String sampleText = "";
+        sampleText += "#\n";
+        sampleText += "\n";
+        sampleText += "msgid \"\"\n";
+        sampleText += "msgstr \"\"\n";
+        sampleText += "\n";
+        sampleText += "msgid \"What is RedPen?\"\n";
+        sampleText += "msgstr \"\"\n";
+        sampleText += "\"RedPenとは？\"\n";
+        sampleText += "\n";
+        Document doc = generateDocument(sampleText);
+        Section section = doc.getLastSection();
+        assertEquals(1, getTotalSentenceCount(section));
+        assertEquals(1, extractParagraphs(section).size());
+
+        assertEquals(1, section.getParagraph(0).getNumberOfSentences());
+        assertEquals(7, section.getParagraph(0).getSentence(0).getLineNumber());
+        assertEquals("RedPenとは？", section.getParagraph(0).getSentence(0).getContent());
+
+    }
+
+    @Test
+    public void testLastMsgstrIsHandled() {
+        String sampleText = "";
+        sampleText += "msgid \"What is RedPen?\"\n";
+        sampleText += "msgstr \"\"\n";
+        sampleText += "\"RedPenとは？\"\n";
+        sampleText += "\n";
+        sampleText += "msgid \"RedPen is a proofreading tool.\"\n";
+        sampleText += "msgstr \"\"\n";
+        sampleText += "\"RedPenは文章の校正ツールです。\"\n";
+
+        Document doc = generateDocument(sampleText);
+        Section section = doc.getLastSection();
+        assertEquals(2, getTotalSentenceCount(section));
+        assertEquals(2, extractParagraphs(section).size());
+
+        assertEquals(1, section.getParagraph(0).getNumberOfSentences());
+        assertEquals(2, section.getParagraph(0).getSentence(0).getLineNumber());
+        assertEquals("RedPenとは？", section.getParagraph(0).getSentence(0).getContent());
+
+        assertEquals(1, section.getParagraph(1).getNumberOfSentences());
+        assertEquals(6, section.getParagraph(1).getSentence(0).getLineNumber());
+        assertEquals("RedPenは文章の校正ツールです。", section.getParagraph(1).getSentence(0).getContent());
+    }
+}


### PR DESCRIPTION
It is useful if RedPen supports portable object by default because it can support technical documents which are translated by gettextize mechanism.