### PR TITLE
module redpen-distribution requires Maven 3.0 or later

### DIFF
--- a/redpen-distribution/pom.xml
+++ b/redpen-distribution/pom.xml
@@ -11,6 +11,9 @@
 
     <artifactId>redpen-distribution</artifactId>
 
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
module redpen-distribution requires Maven 3.0 or later
explicitly describe in pom.xml