### PR TITLE
Check the write permission of $REDPEN_LOG_DIR.

### DIFF
--- a/redpen-server/bin/redpen-server
+++ b/redpen-server/bin/redpen-server
@@ -37,6 +37,7 @@ REDPEN_PORT=8080
 
 # RedPen log file
 REDPEN_LOG_DIR=$REDPEN_HOME/logs
+test -w $REDPEN_LOG_DIR || REDPEN_LOG_DIR=/tmp
 REDPEN_LOG_FILE=$REDPEN_LOG_DIR/redpen.log
 
 #####################################################


### PR DESCRIPTION
Use /tmp as $REDPEN_LOG_DIR if $REDPEN_HOME/logs is unavailable.