### PR TITLE
Skip to validate sentences in blockquote in Markdown parser

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -238,7 +238,6 @@ public class ToFileContentSerializer implements Visitor {
     }
 
     public void visit(BlockQuoteNode blockQuoteNode) {
-        visitChildren(blockQuoteNode);
     }
 
     public void visit(CodeNode codeNode) {

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -897,6 +897,24 @@ public class MarkdownParserTest {
         assertEquals(new LineOffset(1, 19), errors.get(0).getEndPosition().get());
     }
 
+    @Test
+    public void testInvalidSentenceInBlockquote() throws UnsupportedEncodingException, RedPenException {
+        String sampleText = "> This is a good day。\n"; // invalid end of sentence symbol
+        Configuration conf = new Configuration.ConfigurationBuilder()
+                .setLanguage("en")
+                .build();
+        List<Document> documents = new ArrayList<>();
+        documents.add(createFileContent(sampleText, conf));
+
+        Configuration configuration = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(
+                        new ValidatorConfiguration("InvalidSymbol"))
+                .build();
+        RedPen redPen = new RedPen(configuration);
+        List<ValidationError> errors = redPen.validate(documents).get(documents.get(0));
+        assertEquals(0, errors.size());
+    }
+
     private Document createFileContent(String inputDocumentString,
                                        Configuration config) {
         DocumentParser parser = DocumentParser.MARKDOWN;


### PR DESCRIPTION
Fix #465 