### PR TITLE
Sandboxing JavaScript runtime environment

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -223,8 +223,9 @@ public class JavaScriptValidator extends Validator {
                         "var addErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addErrorWithPosition, redpenToBeBound);" +
                         "var addLocalizedError = Function.prototype.bind.call(redpenToBeBound.addLocalizedError, redpenToBeBound);" +
                         "var addLocalizedErrorFromToken = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorFromToken, redpenToBeBound);" +
-                        "var addLocalizedErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorWithPosition, redpenToBeBound);");
-                applySandbox(engine);
+                        "var addLocalizedErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorWithPosition, redpenToBeBound);" +
+                        "var _JavaScriptValidatorTest = Java.type('cc.redpen.validator.JavaScriptValidatorTest');" +
+                        "java = undefined; javax = undefined; Java = undefined; load = undefined; redpenToBeBound = undefined;");
 
                 CompiledScript compiledScript = ((Compilable) engine).compile(script);
                 compiledScript.eval();
@@ -233,10 +234,6 @@ public class JavaScriptValidator extends Validator {
             } catch (ScriptException e) {
                 throw new RedPenException(e);
             }
-        }
-
-        protected void applySandbox(final ScriptEngine engine) throws ScriptException {
-            engine.eval("java = undefined; javax = undefined; Java = undefined; load = undefined; redpenToBeBound = undefined;");
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -224,6 +224,7 @@ public class JavaScriptValidator extends Validator {
                         "var addLocalizedError = Function.prototype.bind.call(redpenToBeBound.addLocalizedError, redpenToBeBound);" +
                         "var addLocalizedErrorFromToken = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorFromToken, redpenToBeBound);" +
                         "var addLocalizedErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorWithPosition, redpenToBeBound);");
+                applySandbox(engine);
 
                 CompiledScript compiledScript = ((Compilable) engine).compile(script);
                 compiledScript.eval();
@@ -232,6 +233,10 @@ public class JavaScriptValidator extends Validator {
             } catch (ScriptException e) {
                 throw new RedPenException(e);
             }
+        }
+
+        protected void applySandbox(final ScriptEngine engine) throws ScriptException {
+            engine.eval("java = undefined; javax = undefined; Java = undefined; load = undefined; redpenToBeBound = undefined;");
         }
     }
 

--- a/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
@@ -89,26 +89,26 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
     @Test
     public void testJSLiteralValidator() throws RedPenException, IOException {
         JavaScriptValidator validator = new JavaScriptValidator();
-        validator.scripts.add(new UnconfinedScript(validator, "testScript.js",
+        validator.scripts.add(new Script(validator, "testScript.js",
                 "function preValidateSentence(sentence) {" +
                         // add function names to "calledFunctions" list upon function calls for the later assertions
                         // the following script is using Nashorn's lobal object "Java".type to access static member:
                         // http://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/api.html
-                        "Java.type('cc.redpen.validator.JavaScriptValidatorTest').calledFunctions.add('preValidateSentence');}" +
+                        "_JavaScriptValidatorTest.calledFunctions.add('preValidateSentence');}" +
                         "function preValidateSection(section) {" +
-                        "Java.type('cc.redpen.validator.JavaScriptValidatorTest').calledFunctions.add('preValidateSection');}" +
+                        "_JavaScriptValidatorTest.calledFunctions.add('preValidateSection');}" +
                         "function validateDocument(document) {" +
-                        "Java.type('cc.redpen.validator.JavaScriptValidatorTest').calledFunctions.add('validateDocument');" +
+                        "_JavaScriptValidatorTest.calledFunctions.add('validateDocument');" +
                         // add ValidationError
                         "addError('validation error', document.getSection(0).getHeaderContent(0));" +
                         // add ValidationError
                         "addLocalizedError(document.getSection(0).getHeaderContent(0), 'doc');}" +
                         "function validateSentence(sentence) {" +
-                        "Java.type('cc.redpen.validator.JavaScriptValidatorTest').calledFunctions.add('validateSentence');" +
+                        "_JavaScriptValidatorTest.calledFunctions.add('validateSentence');" +
                         // add ValidationError
                         "addLocalizedError(sentence, 'sentence');}" +
                         "function validateSection(section) {" +
-                        "Java.type('cc.redpen.validator.JavaScriptValidatorTest').calledFunctions.add('validateSection');" +
+                        "_JavaScriptValidatorTest.calledFunctions.add('validateSection');" +
                         // add ValidationError
                         "addLocalizedError(section.getHeaderContent(0), 'section');}"));
         Document document = new Document.DocumentBuilder()
@@ -193,15 +193,5 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
 
     public void markCalled(String msg) {
         calledFunctions.add(msg);
-    }
-
-    private class UnconfinedScript extends Script {
-        UnconfinedScript(JavaScriptValidator validator, String name, String script) throws RedPenException {
-            super(validator, name, script);
-        }
-
-        @Override
-        protected void applySandbox(final ScriptEngine engine) throws ScriptException {
-        }
     }
 }


### PR DESCRIPTION
Hello,
This is my first attempt to secure the JS validator facility.

I think JS based validators are good to have, but at the same time I feel it's better to have runtime enviroments confined somehow.  I have written some working exploits for RedPen 1.3 or later; if you are interested in, I'll show you.

Changes are:
 - Disable intrinsic Java bridging facilities in order to execute validators
 - Disable intrinsic function to load JS or enable Rhino compatibility in order to execute validators

Please review and hopefully merge.  Keep up good work.
Best,
-t