### PR TITLE
Fixing JS validator failure case

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -223,9 +223,18 @@ public class JavaScriptValidator extends Validator {
                         "var addErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addErrorWithPosition, redpenToBeBound);" +
                         "var addLocalizedError = Function.prototype.bind.call(redpenToBeBound.addLocalizedError, redpenToBeBound);" +
                         "var addLocalizedErrorFromToken = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorFromToken, redpenToBeBound);" +
-                        "var addLocalizedErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorWithPosition, redpenToBeBound);" +
-                        "var _JavaScriptValidatorTest = Java.type('cc.redpen.validator.JavaScriptValidatorTest');" +
-                        "java = undefined; javax = undefined; Java = undefined; load = undefined; redpenToBeBound = undefined;");
+                        "var addLocalizedErrorWithPosition = Function.prototype.bind.call(redpenToBeBound.addLocalizedErrorWithPosition, redpenToBeBound);");
+
+                try {
+                    engine.eval("var _JavaScriptValidatorTest = Java.type('cc.redpen.validator.JavaScriptValidatorTest');");
+                } catch (RuntimeException e) {
+                    if (e.getCause() instanceof ClassNotFoundException) {
+                    } else {
+                        throw e;
+                    }
+                }
+
+                engine.eval("java = undefined; javax = undefined; Java = undefined; load = undefined; redpenToBeBound = undefined;");
 
                 CompiledScript compiledScript = ((Compilable) engine).compile(script);
                 compiledScript.eval();

--- a/redpen-server/src/test/resources/js/pass.js
+++ b/redpen-server/src/test/resources/js/pass.js
@@ -1,0 +1,4 @@
+function validateSentence(s) {
+    // pass
+    addError("called", s);
+}


### PR DESCRIPTION
Hello,
I've fixed the recent breakage of JS validator facility. 
Please review and hopefully merge.

Background:
Currently RedPen seems to choke on executing JS based validators in normal mode operation with RuntimeException.

The RuntimeException originates from the ClassNotFoundException, which occurs during the sandboxing process if the JavaScriptValidatorTest class does not exist (i.e. normal mode.)

(The stack trace:  [stacktrace.txt](https://github.com/redpen-cc/redpen/files/56624/stacktrace.txt))

Changes are:
- redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java: Guarding against ClassNotFoundException based RuntimeException upon test class exposure.
- redpen-server/src/test/java/cc/redpen/server/api/RedPenResourceTest.java: Running JS validators through the JSON interface.
- redpen-server/src/test/resources/js/pass.js: The dummy payload.

Keep up good work.
Best,
-t