### PR TITLE
load dictionary files and JavaScript valdiators only from directories under $REDPEN_HOME for the security reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ target
 
 # misc
 *~
+
+# Maven
+*.releaseBackup

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
                     <consoleOutput>true</consoleOutput>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.4.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.9</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cc.redpen</groupId>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3</version>
     <artifactId>redpen</artifactId>
     <url>http://redpen.cc</url>
     <name>redpen</name>
@@ -32,7 +32,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cc.redpen</groupId>
-    <version>1.4.3</version>
+    <version>1.4.4-SNAPSHOT</version>
     <artifactId>redpen</artifactId>
     <url>http://redpen.cc</url>
     <name>redpen</name>
@@ -32,7 +32,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/redpen-cli/pom.xml
+++ b/redpen-cli/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>cc.redpen</groupId>
         <artifactId>redpen</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>redpen-cli</artifactId>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3</version>
     <name>redpen-cli</name>
     <description>RedPen is an open source proofreading tool a tool to check if your technical documents meet the writing standard . RedPen supports various markup text formats (Markdown, Textile, AsciiDoc, and LaTeX).</description>
     <url>http://redpen.cc</url>
@@ -50,7 +50,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <properties>
@@ -106,12 +106,12 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3-SNAPSHOT</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-plugin</artifactId>
-            <version>1.4.3-SNAPSHOT</version>
+            <version>1.4.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/redpen-cli/pom.xml
+++ b/redpen-cli/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>cc.redpen</groupId>
         <artifactId>redpen</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>redpen-cli</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4-SNAPSHOT</version>
     <name>redpen-cli</name>
     <description>RedPen is an open source proofreading tool a tool to check if your technical documents meet the writing standard . RedPen supports various markup text formats (Markdown, Textile, AsciiDoc, and LaTeX).</description>
     <url>http://redpen.cc</url>
@@ -50,7 +50,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>
@@ -106,12 +106,12 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-plugin</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>cc.redpen</groupId>
         <artifactId>redpen</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>redpen-core</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4-SNAPSHOT</version>
     <name>redpen-core</name>
     <description>RedPen is an open source proofreading tool a tool to check if your technical documents meet the writing standard . RedPen supports various markup text formats (Markdown, Textile, AsciiDoc, and LaTeX).</description>
     <url>http://redpen.cc</url>
@@ -49,7 +49,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>cc.redpen</groupId>
         <artifactId>redpen</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>redpen-core</artifactId>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3</version>
     <name>redpen-core</name>
     <description>RedPen is an open source proofreading tool a tool to check if your technical documents meet the writing standard . RedPen supports various markup text formats (Markdown, Textile, AsciiDoc, and LaTeX).</description>
     <url>http://redpen.cc</url>
@@ -49,7 +49,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <properties>

--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -46,7 +46,7 @@ import java.util.Map;
 public class RedPen {
     private static final Logger LOG = LoggerFactory.getLogger(RedPen.class);
 
-    public static final String VERSION = "1.4.1";
+    public static final String VERSION = "1.4.3";
 
     private final Configuration configuration;
     private final SentenceExtractor sentenceExtractor;

--- a/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
@@ -23,7 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -121,6 +122,7 @@ public final class DictionaryLoader<E> {
      */
     public E loadCachedFromFile(File file, String dictionaryName) throws RedPenException {
         String path = file.getAbsolutePath();
+        ensureFileIsInsideRedPenHome(path);
         if (!file.exists()) {
             throw new RedPenException("File not found: " + file);
         }
@@ -151,5 +153,25 @@ public final class DictionaryLoader<E> {
         }
         LOG.info("Succeeded to load " + dictionaryName + ".");
         return loaded;
+    }
+
+    /**
+     * Test the specified path is inside $REDPEN_HOME. If not, throw RedPenException
+     * @param canonicalPath path to test
+     * @throws RedPenException the specified path is not inside $REDPEN_HOME
+     */
+    public static void ensureFileIsInsideRedPenHome(String canonicalPath) throws RedPenException{
+        String home = System.getenv("REDPEN_HOME");
+        if(home == null){
+            home = System.getProperty("REDPEN_HOME");
+        }
+
+        if (home != null) {
+            String homeAbsolutePath = new File(home).getAbsolutePath();
+            if (!canonicalPath.startsWith(homeAbsolutePath)) {
+                throw new RedPenException(canonicalPath + " is not under $REDPEN_HOME:" + homeAbsolutePath);
+            }
+        }
+
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
@@ -122,7 +122,7 @@ public final class DictionaryLoader<E> {
      */
     public E loadCachedFromFile(File file, String dictionaryName) throws RedPenException {
         String path = file.getAbsolutePath();
-        ensureFileIsInsideRedPenHome(path);
+        ensureFileIsInsideRedPenHomeOrWorkingDirectory(path);
         if (!file.exists()) {
             throw new RedPenException("File not found: " + file);
         }
@@ -156,22 +156,33 @@ public final class DictionaryLoader<E> {
     }
 
     /**
-     * Test the specified path is inside $REDPEN_HOME. If not, throw RedPenException
-     * @param canonicalPath path to test
+     * Test the specified path is inside $REDPEN_HOME, or JVM working directory. If not, throw RedPenException
+     *
+     * @param path path to test
      * @throws RedPenException the specified path is not inside $REDPEN_HOME
      */
-    public static void ensureFileIsInsideRedPenHome(String canonicalPath) throws RedPenException{
-        String home = System.getenv("REDPEN_HOME");
-        if(home == null){
-            home = System.getProperty("REDPEN_HOME");
-        }
+    public static void ensureFileIsInsideRedPenHomeOrWorkingDirectory(String path) throws RedPenException {
+            try {
+                String canonicalPath = new File(path).getCanonicalPath();
+                String currentDirectory = new File("").getCanonicalPath();
+                if (canonicalPath.startsWith(currentDirectory)) {
+                    return;
+                }
+                String home = System.getProperty("REDPEN_HOME", System.getenv("REDPEN_HOME"));
+                String homeCanonicalPath;
+                if (home != null) {
+                    homeCanonicalPath = new File(home).getCanonicalPath();
+                    if (canonicalPath.startsWith(homeCanonicalPath)) {
+                        return;
+                    }
+                }else{
+                    homeCanonicalPath = "not specified";
+                }
+                throw new RedPenException(String.format("%s  is not under $REDPEN_HOME(%s) or current directory(%s).",
+                        canonicalPath , homeCanonicalPath, currentDirectory));
 
-        if (home != null) {
-            String homeAbsolutePath = new File(home).getAbsolutePath();
-            if (!canonicalPath.startsWith(homeAbsolutePath)) {
-                throw new RedPenException(canonicalPath + " is not under $REDPEN_HOME:" + homeAbsolutePath);
+            } catch (IOException e) {
+                throw new RedPenException(e);
             }
-        }
-
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -22,6 +22,7 @@ import cc.redpen.model.Document;
 import cc.redpen.model.Section;
 import cc.redpen.model.Sentence;
 import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.util.DictionaryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,7 @@ public class JavaScriptValidator extends Validator {
                         } catch (IOException e) {
                             LOG.error("Exception while reading js file", e);
                         }
-                    }
+                1    }
                 }
             }
         }

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -22,6 +22,7 @@ import cc.redpen.model.Document;
 import cc.redpen.model.Section;
 import cc.redpen.model.Sentence;
 import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.util.DictionaryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,13 +63,15 @@ public class JavaScriptValidator extends Validator {
 
     @Override
     protected void init() throws RedPenException {
+        String home = System.getenv("REDPEN_HOME");
         String jsValidatorsPath = getConfigAttribute("script-path").orElse(
-                System.getenv("REDPEN_HOME") + File.separator + DEFAULT_JS_VALIDATORS_PATH);
+                home + "/" + DEFAULT_JS_VALIDATORS_PATH);
         File jsDirectory = new File(jsValidatorsPath);
         if(!jsDirectory.exists()){
-            LOG.info("JavaScript validators directory is missing: {}", jsDirectory.getAbsolutePath());
+            LOG.info("JavaScript validators directory is missing: {}", jsValidatorsPath);
         }else {
-            LOG.info("JavaScript validators directory: {}", jsDirectory.getAbsolutePath());
+            LOG.info("JavaScript validators directory: {}", jsValidatorsPath);
+            DictionaryLoader.ensureFileIsInsideRedPenHome(jsValidatorsPath);
             File[] jsValidatorFiles = jsDirectory.listFiles();
             if (jsValidatorFiles != null) {
                 for (File file : jsValidatorFiles) {

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -63,14 +63,16 @@ public class JavaScriptValidator extends Validator {
 
     @Override
     protected void init() throws RedPenException {
-        String jsValidatorsPath = getConfigAttribute("script-path").orElse(
-                System.getenv("REDPEN_HOME") + "/" + DEFAULT_JS_VALIDATORS_PATH);
+        String home = System.getProperty("REDPEN_HOME", System.getenv("REDPEN_HOME"));
+        home = home != null ? home : ".";
+
+        String jsValidatorsPath = getConfigAttribute("script-path").orElse(home + File.separator + DEFAULT_JS_VALIDATORS_PATH);
         File jsDirectory = new File(jsValidatorsPath);
         if(!jsDirectory.exists()){
             LOG.info("JavaScript validators directory is missing: {}", jsValidatorsPath);
         }else {
             LOG.info("JavaScript validators directory: {}", jsValidatorsPath);
-            DictionaryLoader.ensureFileIsInsideRedPenHome(jsValidatorsPath);
+            DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(jsValidatorsPath);
             File[] jsValidatorFiles = jsDirectory.listFiles();
             if (jsValidatorFiles != null) {
                 for (File file : jsValidatorFiles) {

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -80,7 +80,7 @@ public class JavaScriptValidator extends Validator {
                         } catch (IOException e) {
                             LOG.error("Exception while reading js file", e);
                         }
-                1    }
+                    }
                 }
             }
         }

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -107,14 +107,15 @@ public class DictionaryLoaderTest extends Validator {
     }
 
     @Test
-    public void testEnsureFileIsInsideRedPenHome() throws RedPenException, IOException {
+    public void testEnsureFileIsInsideRedPenHomeOrWorkingDirectory() throws RedPenException, IOException {
         File tempFile = File.createTempFile("redpenTest", "redpenTest");
         String path = tempFile.getAbsolutePath();
         System.setProperty("REDPEN_HOME", path);
-        DictionaryLoader.ensureFileIsInsideRedPenHome(path + File.separator + "test");
+        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(path + File.separator + "test");
+        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(new File("fileInCurrentDirectory.txt").getCanonicalPath());
         try {
             File file = new File(path + File.separator + ".." + File.separator + "test");
-            DictionaryLoader.ensureFileIsInsideRedPenHome(file.getCanonicalPath());
+            DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(file.getCanonicalPath());
             fail("expecting RedPenException");
         } catch (RedPenException expected) {
         }

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -25,12 +25,15 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DictionaryLoaderTest extends Validator {
     @Test
@@ -102,5 +105,21 @@ public class DictionaryLoaderTest extends Validator {
         assertEquals(2, strings.size());
         assertTrue(strings.contains("foo"));
         assertTrue(strings.contains("bar"));
+    }
+
+    @Test
+    public void testEnsureFileIsInsideRedPenHome() throws RedPenException, IOException {
+        File tempFile = File.createTempFile("redpenTest", "redpenTest");
+        String path = tempFile.getAbsolutePath();
+        System.setProperty("REDPEN_HOME", path);
+        String s = File.separator;
+        System.out.println(s);
+        DictionaryLoader.ensureFileIsInsideRedPenHome(path + File.separator + "test");
+        try {
+            File file = new File(path + File.separator + ".." + File.separator + "test");
+            DictionaryLoader.ensureFileIsInsideRedPenHome(file.getCanonicalPath());
+            fail("expecting RedPenException");
+        } catch (RedPenException expected) {
+        }
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -76,6 +76,7 @@ public class DictionaryLoaderTest extends Validator {
     public void testLoadCachedFile() throws IOException, RedPenException {
         Path path = Files.createTempFile("test", "txt");
         File file = path.toFile();
+        System.setProperty("REDPEN_HOME", file.getParentFile().getAbsolutePath());
         Files.copy(new ByteArrayInputStream("foo".getBytes()), path, StandardCopyOption.REPLACE_EXISTING);
         Set<String> strings;
         strings = WORD_LIST.loadCachedFromFile(path.toFile(), "temp file");

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -78,6 +78,7 @@ public class DictionaryLoaderTest extends Validator {
     public void testLoadCachedFile() throws IOException, RedPenException {
         Path path = Files.createTempFile("test", "txt");
         File file = path.toFile();
+        System.setProperty("REDPEN_HOME", file.getAbsolutePath());
         Files.copy(new ByteArrayInputStream("foo".getBytes()), path, StandardCopyOption.REPLACE_EXISTING);
         Set<String> strings;
         strings = WORD_LIST.loadCachedFromFile(path.toFile(), "temp file");
@@ -112,8 +113,6 @@ public class DictionaryLoaderTest extends Validator {
         File tempFile = File.createTempFile("redpenTest", "redpenTest");
         String path = tempFile.getAbsolutePath();
         System.setProperty("REDPEN_HOME", path);
-        String s = File.separator;
-        System.out.println(s);
         DictionaryLoader.ensureFileIsInsideRedPenHome(path + File.separator + "test");
         try {
             File file = new File(path + File.separator + ".." + File.separator + "test");

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DictionaryLoaderTest extends Validator {
     @Test

--- a/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
@@ -62,6 +62,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
         // delete the temporary file, make a directory, and store JavaScript validator in it
         javaScriptValidatorsDir.delete();
         javaScriptValidatorsDir.mkdirs();
+        System.setProperty("REDPEN_HOME",javaScriptValidatorsDir.getAbsolutePath());
         File validatorJS = new File(javaScriptValidatorsDir.getAbsolutePath() + File.separator + "MyValidator.js");
         String content2 = "function validateSentence(sentence) {\n" +
                 "addLocalizedError(sentence, 'validation error in JavaScript Validator');}";

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
@@ -26,7 +26,8 @@ import cc.redpen.RedPenException;
 import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Document;
-import cc.redpen.model.Sentence;
+
+import java.io.File;
 import java.util.Map;
 
 import java.util.ArrayList;
@@ -211,6 +212,7 @@ public class KatakanaEndHyphenValidatorTest {
                         .addSentence(new Sentence("コーヒーと紅茶と、どちらがお好きですか。", 1))
                         .build());
 
+        System.setProperty("REDPEN_HOME",new File("src/test/resources/").getAbsolutePath());
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         assertEquals(0, errors.get(documents.get(0)).size());

--- a/redpen-distribution/pom.xml
+++ b/redpen-distribution/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <build>

--- a/redpen-distribution/pom.xml
+++ b/redpen-distribution/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/redpen-plugin/pom.xml
+++ b/redpen-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/redpen-plugin/pom.xml
+++ b/redpen-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <build>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3-SNAPSHOT</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -48,7 +48,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>redpen-1.4.3</tag>
   </scm>
 
     <build>
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3-SNAPSHOT</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.wink</groupId>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>redpen</artifactId>
         <groupId>cc.redpen</groupId>
-        <version>1.4.3</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -48,7 +48,7 @@
         <url>https://github.com/redpen-cc/redpen</url>
         <connection>scm:git:https://github.com/redpen-cc/redpen.git</connection>
         <developerConnection>scm:git:https://github.com/redpen-cc/redpen.git</developerConnection>
-      <tag>redpen-1.4.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>cc.redpen</groupId>
             <artifactId>redpen-core</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.wink</groupId>


### PR DESCRIPTION
load dictionary files and JavaScript valdiators only from directories under $REDPEN_HOME for the security reasons

Allowing clients to specify any file can be vulnerable.
This fix will lower the risk.
