### PR TITLE
Expose symbol types in RedPen Server API

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -79,6 +79,15 @@ public final class Configuration {
     }
 
     /**
+     * returns symbol table type targeted by this configuration
+     *
+     * @return type
+     */
+    public String getType() {
+        return getSymbolTable().getType();
+    }
+
+    /**
      * returns Tokenizer aasociated with this configuration
      *
      * @return tokenizer

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 /**
  * Contains Settings used throughout {@link cc.redpen.RedPen}.
  */
@@ -94,6 +96,14 @@ public final class Configuration {
      */
     public RedPenTokenizer getTokenizer() {
         return tokenizer;
+    }
+
+    /**
+     * @return unique key for this lang and type combination
+     */
+    public String getKey() {
+        if (getLang().equals("ja") && getType().equals("zenkaku")) return "ja";
+        return getLang() + (isEmpty(getType()) ? "" : "." + getType());
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -30,7 +30,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 /**
  * Contains Settings used throughout {@link cc.redpen.RedPen}.
  */
-public final class Configuration {
+public class Configuration {
     private final SymbolTable symbolTable;
     private final List<ValidatorConfiguration> validatorConfigs = new ArrayList<>();
     private String lang;

--- a/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
+++ b/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
@@ -33,7 +33,7 @@ public final class SymbolTable implements Serializable {
     private static final long serialVersionUID = 1612920745151501631L;
     private final Map<SymbolType, Symbol> symbolDictionary = new HashMap<>();
     private final Map<Character, Symbol> valueDictionary = new HashMap<>();
-    private final String type;
+    private String type;
     private String lang;
     private static final Logger LOG = LoggerFactory.getLogger(SymbolTable.class);
 
@@ -55,7 +55,8 @@ public final class SymbolTable implements Serializable {
                 this.overrideSymbol(new Symbol(FULL_STOP, '．', "。."));
                 this.overrideSymbol(new Symbol(COMMA, '，', "、,"));
             } else {
-                LOG.info("\"normal\" type is specified");
+                this.type = "zenkaku";
+                LOG.info("\"zenkaku\" type is specified");
                 JAPANESE_SYMBOLS.values().forEach(this::overrideSymbol);
             }
         } else {
@@ -129,6 +130,10 @@ public final class SymbolTable implements Serializable {
 
     public String getLang() {
         return lang;
+    }
+
+    public String getType() {
+        return type;
     }
 
     @Override

--- a/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
+++ b/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
@@ -29,7 +29,7 @@ import static cc.redpen.config.SymbolType.*;
 /**
  * Configuration table of characters used in {@link cc.redpen.RedPen}.
  */
-public final class SymbolTable implements Serializable {
+public class SymbolTable implements Serializable {
     private static final long serialVersionUID = 1612920745151501631L;
     private final Map<SymbolType, Symbol> symbolDictionary = new HashMap<>();
     private final Map<Character, Symbol> valueDictionary = new HashMap<>();

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -19,6 +19,9 @@ package cc.redpen.config;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.*;
 
 /**
@@ -69,5 +72,23 @@ public class ConfigurationTest {
         Configuration configuration = new Configuration.ConfigurationBuilder().build(); // NOTE: load "en" setting when lang is not specified
         assertEquals("en", configuration.getLang());
         assertNotNull(configuration.getLang());
+    }
+
+    @Test
+    public void keyIsLangAndType() throws Exception {
+        SymbolTable symbolTable = new SymbolTable("ja", Optional.of("hankaku"), emptyList());
+        assertEquals("ja.hankaku", new Configuration(symbolTable, emptyList(), "ja").getKey());
+    }
+
+    @Test
+    public void keyIsLangOnlyIfTypeIsMissing() throws Exception {
+        SymbolTable symbolTable = new SymbolTable("en", Optional.empty(), emptyList());
+        assertEquals("en", new Configuration(symbolTable, emptyList(), "en").getKey());
+    }
+
+    @Test
+    public void keyIsLangOnlyForZenkaku() throws Exception {
+        SymbolTable symbolTable = new SymbolTable("ja", Optional.of("zenkaku"), emptyList());
+        assertEquals("ja", new Configuration(symbolTable, emptyList(), "ja").getKey());
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/config/SymbolTableTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/SymbolTableTest.java
@@ -1,0 +1,42 @@
+package cc.redpen.config;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static cc.redpen.config.SymbolType.COMMA;
+import static cc.redpen.config.SymbolType.FULL_STOP;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+public class SymbolTableTest {
+  @Test
+  public void englishDoesNotHaveAType() throws Exception {
+    SymbolTable table = new SymbolTable("en", Optional.empty(), emptyList());
+    assertEquals("", table.getType());
+  }
+
+  @Test
+  public void japaneseUsesZenkakuByDefault() throws Exception {
+    SymbolTable table = new SymbolTable("ja", Optional.empty(), emptyList());
+    assertEquals("zenkaku", table.getType());
+    assertEquals('。', table.getSymbol(FULL_STOP).getValue());
+    assertEquals('、', table.getSymbol(COMMA).getValue());
+  }
+
+  @Test
+  public void japaneseCanUseAVariationOfZenkaku() throws Exception {
+    SymbolTable table = new SymbolTable("ja", Optional.of("zenkaku2"), emptyList());
+    assertEquals("zenkaku2", table.getType());
+    assertEquals('．', table.getSymbol(FULL_STOP).getValue());
+    assertEquals('，', table.getSymbol(COMMA).getValue());
+  }
+
+  @Test
+  public void japaneseCanUseHankaku() throws Exception {
+    SymbolTable table = new SymbolTable("ja", Optional.of("hankaku"), emptyList());
+    assertEquals("hankaku", table.getType());
+    assertEquals('.', table.getSymbol(FULL_STOP).getValue());
+    assertEquals(',', table.getSymbol(COMMA).getValue());
+  }
+}

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -236,6 +236,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.codeborne</groupId>
             <artifactId>selenide</artifactId>
             <version>3.1.1</version>

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
@@ -71,6 +71,7 @@ public class RedPenConfigurationResource {
                         // add specific configuration items
                         JSONObject config = new JSONObject();
                         config.put("lang", redPen.getConfiguration().getLang());
+                        config.put("type", redPen.getConfiguration().getType());
                         config.put("tokenizer", redPen.getConfiguration().getTokenizer().getClass().getName());
 
                         // add the names of the validators

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
@@ -48,6 +48,10 @@ public class RedPenConfigurationResource {
     @Context
     private ServletContext context;
 
+    RedPenService getRedPenService() {
+        return new RedPenService(context);
+    }
+
     @Path("/redpens")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -62,7 +66,7 @@ public class RedPenConfigurationResource {
             response.put("documentParsers", DocumentParser.PARSER_MAP.keySet());
 
             // add matching configurations
-            Map<String, RedPen> redpens = new RedPenService(context).getRedPens();
+            Map<String, RedPen> redpens = getRedPenService().getRedPens();
             final JSONObject redpensJSON = new JSONObject();
             response.put("redpens", redpensJSON);
             redpens.forEach((configurationName, redPen) -> {
@@ -79,8 +83,8 @@ public class RedPenConfigurationResource {
                         for (Validator validator : redPen.getValidators()) {
                             JSONObject validatorJSON = new JSONObject();
                             String name = validator.getClass().getSimpleName().endsWith("Validator")
-                                    ? validator.getClass().getSimpleName().substring(0, validator.getClass().getSimpleName().length() - 9)
-                                    : validator.getClass().getSimpleName();
+                              ? validator.getClass().getSimpleName().substring(0, validator.getClass().getSimpleName().length() - 9)
+                              : validator.getClass().getSimpleName();
                             validatorJSON.put("languages", validator.getSupportedLanguages());
                             validatorJSON.put("properties", validator.getConfigAttributes());
                             validatorConfigs.put(name, validatorJSON);
@@ -101,12 +105,14 @@ public class RedPenConfigurationResource {
                         config.put("symbols", symbolConfigs);
 
                         redpensJSON.put(configurationName, config);
-                    } catch (Exception e) {
+                    }
+                    catch (Exception e) {
                         LOG.error("Exception when rendering RedPen to JSON for configuration " + configurationName, e);
                     }
                 }
             });
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             LOG.error("Exception when rendering RedPen to JSON", e);
         }
 

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
@@ -56,17 +56,15 @@ public class RedPenService {
                     RedPen japaneseRedPen = new RedPen("/conf/redpen-conf-ja.xml");
                     langRedPenMap.put("ja", japaneseRedPen);
 
-                    String configPath;
-                    if (context != null) {
-                        configPath = context.getInitParameter("redpen.conf.path");
-                        if (configPath != null) {
-                            LOG.info("Config Path is set to \"{}\"", configPath);
-                            RedPen defaultRedPen = new RedPen(configPath);
-                            langRedPenMap.put(DEFAULT_LANGUAGE, defaultRedPen);
-                        } else {
-                            // if config path is not set, fallback to default config path
-                            LOG.info("Config Path is set to \"{}\"", DEFAULT_INTERNAL_CONFIG_PATH);
-                        }
+                    String configPath = context != null ? context.getInitParameter("redpen.conf.path") : null;
+                    if (configPath != null) {
+                        LOG.info("Config Path is set to \"{}\"", configPath);
+                        RedPen defaultRedPen = new RedPen(configPath);
+                        langRedPenMap.put(DEFAULT_LANGUAGE, defaultRedPen);
+                    } else {
+                        // if config path is not set, fallback to default config path
+                        LOG.info("Config Path is set to \"{}\"", DEFAULT_INTERNAL_CONFIG_PATH);
+                        langRedPenMap.put(DEFAULT_LANGUAGE, englishRedPen);
                     }
                     LOG.info("Document Validator Server is running.");
                 } catch (RedPenException e) {

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
@@ -60,8 +60,9 @@ public class RedPenService {
                 LOG.info("Creating RedPen instances");
                 try {
                     for (String fileName : findConfFiles()) {
-                        RedPen conf = new RedPen(fileName);
-                        langRedPenMap.put(conf.getConfiguration().getLang(), conf);
+                        RedPen redPen = new RedPen(fileName);
+                        Configuration config = redPen.getConfiguration();
+                        langRedPenMap.put(config.getKey(), redPen);
                     }
 
                     String configPath = context != null ? context.getInitParameter("redpen.conf.path") : null;

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
@@ -24,10 +24,18 @@ import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 import javax.servlet.ServletContext;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Helper class to access RedPen instances for use within the webapp
@@ -51,10 +59,10 @@ public class RedPenService {
             if (langRedPenMap.size() == 0) {
                 LOG.info("Creating RedPen instances");
                 try {
-                    RedPen englishRedPen = new RedPen(DEFAULT_INTERNAL_CONFIG_PATH);
-                    langRedPenMap.put("en", englishRedPen);
-                    RedPen japaneseRedPen = new RedPen("/conf/redpen-conf-ja.xml");
-                    langRedPenMap.put("ja", japaneseRedPen);
+                    for (String fileName : findConfFiles()) {
+                        RedPen conf = new RedPen(fileName);
+                        langRedPenMap.put(conf.getConfiguration().getLang(), conf);
+                    }
 
                     String configPath = context != null ? context.getInitParameter("redpen.conf.path") : null;
                     if (configPath != null) {
@@ -64,7 +72,7 @@ public class RedPenService {
                     } else {
                         // if config path is not set, fallback to default config path
                         LOG.info("Config Path is set to \"{}\"", DEFAULT_INTERNAL_CONFIG_PATH);
-                        langRedPenMap.put(DEFAULT_LANGUAGE, englishRedPen);
+                        langRedPenMap.put(DEFAULT_LANGUAGE, langRedPenMap.get("en"));
                     }
                     LOG.info("Document Validator Server is running.");
                 } catch (RedPenException e) {
@@ -72,6 +80,17 @@ public class RedPenService {
                     throw new ExceptionInInitializerError(e);
                 }
             }
+        }
+    }
+
+    private Set<String> findConfFiles() {
+        try {
+            Resource[] resources = new PathMatchingResourcePatternResolver(getClass().getClassLoader()).getResources("classpath*:conf/*.xml");
+            return Stream.of(resources).map(r -> "/conf/" + r.getFilename()).collect(toSet());
+        }
+        catch (IOException e) {
+            LOG.error("Failed to load default config files", e);
+            return emptySet();
         }
     }
 

--- a/redpen-server/src/main/resources/conf/redpen-conf-ja-hankaku.xml
+++ b/redpen-server/src/main/resources/conf/redpen-conf-ja-hankaku.xml
@@ -1,0 +1,19 @@
+<redpen-conf lang="ja" type="hankaku">
+    <validators>
+        <validator name="SentenceLength">
+            <property name="max_len" value="100"/>
+        </validator>
+        <validator name="InvalidSymbol"/>
+        <validator name="KatakanaEndHyphen"/>
+        <validator name="KatakanaSpellCheck"/>
+        <validator name="SectionLength">
+            <property name="max_num" value="1500"/>
+        </validator>
+        <validator name="ParagraphNumber"/>
+        <validator name="DoubledWord" />
+        <validator name="SpaceBetweenAlphabeticalWord" />
+        <validator name="CommaNumber" />
+        <validator name="SuccessiveWord" />
+        <validator name="HankakuKana" />
+    </validators>
+</redpen-conf>

--- a/redpen-server/src/main/resources/conf/redpen-conf-ja-zenkaku2.xml
+++ b/redpen-server/src/main/resources/conf/redpen-conf-ja-zenkaku2.xml
@@ -1,0 +1,19 @@
+<redpen-conf lang="ja" type="zenkaku2">
+    <validators>
+        <validator name="SentenceLength">
+            <property name="max_len" value="100"/>
+        </validator>
+        <validator name="InvalidSymbol"/>
+        <validator name="KatakanaEndHyphen"/>
+        <validator name="KatakanaSpellCheck"/>
+        <validator name="SectionLength">
+            <property name="max_num" value="1500"/>
+        </validator>
+        <validator name="ParagraphNumber"/>
+        <validator name="DoubledWord" />
+        <validator name="SpaceBetweenAlphabeticalWord" />
+        <validator name="CommaNumber" />
+        <validator name="SuccessiveWord" />
+        <validator name="HankakuKana" />
+    </validators>
+</redpen-conf>

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
@@ -1,0 +1,42 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen.server.api;
+
+import cc.redpen.RedPen;
+import cc.redpen.parser.DocumentParser;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RedPenConfigurationResourceTest {
+    RedPenConfigurationResource resource = new RedPenConfigurationResource();
+
+    @Test
+    public void versionIsReturned() throws Exception {
+        JSONObject response = (JSONObject)resource.getRedPens("").getEntity();
+        assertEquals(RedPen.VERSION, response.getString("version"));
+    }
+
+    @Test
+    public void availableDocumentParsersAreReturned() throws Exception {
+        JSONObject response = (JSONObject)resource.getRedPens("").getEntity();
+        assertEquals(new JSONArray(DocumentParser.PARSER_MAP.keySet()).toString(), response.get("documentParsers").toString());
+    }
+}

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
@@ -48,7 +48,7 @@ public class RedPenConfigurationResourceTest {
         JSONObject response = (JSONObject)resource.getRedPens(null).getEntity();
         JSONObject redpens = response.getJSONObject("redpens");
 
-        assertEquals(2, redpens.length());
+        assertEquals(3, redpens.length());
 
         JSONObject en = redpens.getJSONObject("en");
         assertEquals("en", en.getString("lang"));

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
@@ -20,13 +20,13 @@ package cc.redpen.server.api;
 import cc.redpen.RedPen;
 import cc.redpen.parser.DocumentParser;
 import cc.redpen.tokenizer.JapaneseTokenizer;
-import cc.redpen.tokenizer.WhiteSpaceTokenizer;
+import com.google.common.collect.ImmutableMap;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class RedPenConfigurationResourceTest {
     RedPenConfigurationResource resource = new RedPenConfigurationResource();
@@ -45,17 +45,27 @@ public class RedPenConfigurationResourceTest {
 
     @Test
     public void allConfigurationsIfLangNotSpecified() throws Exception {
+        RedPenService service = mock(RedPenService.class);
+        RedPen redPen = mock(RedPen.class, RETURNS_DEEP_STUBS);
+        doReturn(ImmutableMap.of("en", redPen, "ja", redPen, "et", redPen)).when(service).getRedPens();
+
+        resource = spy(resource);
+        doReturn(service).when(resource).getRedPenService();
+
         JSONObject response = (JSONObject)resource.getRedPens(null).getEntity();
         JSONObject redpens = response.getJSONObject("redpens");
 
         assertEquals(3, redpens.length());
 
-        JSONObject en = redpens.getJSONObject("en");
-        assertEquals("en", en.getString("lang"));
-        assertEquals("", en.getString("type"));
-        assertEquals(WhiteSpaceTokenizer.class.getName(), en.getString("tokenizer"));
-        assertTrue(!en.getString("validators").isEmpty());
-        assertTrue(!en.getString("symbols").isEmpty());
+        assertNotNull(redpens.getJSONObject("en"));
+        assertNotNull(redpens.getJSONObject("ja"));
+        assertNotNull(redpens.getJSONObject("et"));
+    }
+
+    @Test
+    public void redPenFields() throws Exception {
+        JSONObject response = (JSONObject)resource.getRedPens(null).getEntity();
+        JSONObject redpens = response.getJSONObject("redpens");
 
         JSONObject ja = redpens.getJSONObject("ja");
         assertEquals("ja", ja.getString("lang"));

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenConfigurationResourceTest.java
@@ -19,11 +19,14 @@ package cc.redpen.server.api;
 
 import cc.redpen.RedPen;
 import cc.redpen.parser.DocumentParser;
+import cc.redpen.tokenizer.JapaneseTokenizer;
+import cc.redpen.tokenizer.WhiteSpaceTokenizer;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RedPenConfigurationResourceTest {
     RedPenConfigurationResource resource = new RedPenConfigurationResource();
@@ -38,5 +41,27 @@ public class RedPenConfigurationResourceTest {
     public void availableDocumentParsersAreReturned() throws Exception {
         JSONObject response = (JSONObject)resource.getRedPens("").getEntity();
         assertEquals(new JSONArray(DocumentParser.PARSER_MAP.keySet()).toString(), response.get("documentParsers").toString());
+    }
+
+    @Test
+    public void allConfigurationsIfLangNotSpecified() throws Exception {
+        JSONObject response = (JSONObject)resource.getRedPens(null).getEntity();
+        JSONObject redpens = response.getJSONObject("redpens");
+
+        assertEquals(2, redpens.length());
+
+        JSONObject en = redpens.getJSONObject("en");
+        assertEquals("en", en.getString("lang"));
+        assertEquals("", en.getString("type"));
+        assertEquals(WhiteSpaceTokenizer.class.getName(), en.getString("tokenizer"));
+        assertTrue(!en.getString("validators").isEmpty());
+        assertTrue(!en.getString("symbols").isEmpty());
+
+        JSONObject ja = redpens.getJSONObject("ja");
+        assertEquals("ja", ja.getString("lang"));
+        assertEquals("zenkaku", ja.getString("type"));
+        assertEquals(JapaneseTokenizer.class.getName(), ja.getString("tokenizer"));
+        assertTrue(!ja.getString("validators").isEmpty());
+        assertTrue(!ja.getString("symbols").isEmpty());
     }
 }

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenResourceTest.java
@@ -33,16 +33,6 @@ import java.util.Set;
 public class RedPenResourceTest extends MockServletInvocationTest {
 
     @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
-    @Override
     protected Class<?>[] getClasses() {
         try {
             Set<Class<?>> classes = new ApplicationFileLoader("application").getClasses();

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
@@ -1,0 +1,19 @@
+package cc.redpen.server.api;
+
+import cc.redpen.RedPen;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class RedPenServiceTest {
+  @Test
+  public void twoConfigurationsByDefault() throws Exception {
+    RedPenService service = new RedPenService(null);
+    Map<String, RedPen> redPens = service.getRedPens();
+    assertEquals(2, redPens.size());
+    assertEquals("en", redPens.get("en").getConfiguration().getLang());
+    assertEquals("ja", redPens.get("ja").getConfiguration().getLang());
+  }
+}

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
@@ -12,9 +12,17 @@ public class RedPenServiceTest {
   public void twoConfigurationsByDefault() throws Exception {
     RedPenService service = new RedPenService(null);
     Map<String, RedPen> redPens = service.getRedPens();
-    assertEquals(3, redPens.size());
+    assertEquals(5, redPens.size());
     assertEquals("en", redPens.get("default").getConfiguration().getLang());
     assertEquals("en", redPens.get("en").getConfiguration().getLang());
+
     assertEquals("ja", redPens.get("ja").getConfiguration().getLang());
+    assertEquals("zenkaku", redPens.get("ja").getConfiguration().getType());
+
+    assertEquals("ja", redPens.get("ja.zenkaku2").getConfiguration().getLang());
+    assertEquals("zenkaku2", redPens.get("ja.zenkaku2").getConfiguration().getType());
+
+    assertEquals("ja", redPens.get("ja.hankaku").getConfiguration().getLang());
+    assertEquals("hankaku", redPens.get("ja.hankaku").getConfiguration().getType());
   }
 }

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
@@ -12,7 +12,8 @@ public class RedPenServiceTest {
   public void twoConfigurationsByDefault() throws Exception {
     RedPenService service = new RedPenService(null);
     Map<String, RedPen> redPens = service.getRedPens();
-    assertEquals(2, redPens.size());
+    assertEquals(3, redPens.size());
+    assertEquals("en", redPens.get("default").getConfiguration().getLang());
     assertEquals("en", redPens.get("en").getConfiguration().getLang());
     assertEquals("ja", redPens.get("ja").getConfiguration().getLang());
   }


### PR DESCRIPTION
Also include default configurations for hankaku and zenkaku2 types.