### PR TITLE
Allow CORS (Cross-Origin AJAX requests)

### DIFF
--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
@@ -35,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import static cc.redpen.config.SymbolType.*;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
@@ -107,9 +109,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
         assertEquals(2, errors.get(document).size());
-        //NOTE: commented out since the following asserts fails because order of the errors could be changed depending on the environment.
-        //assertEquals("Need whitespace after symbol \")\".", errors.get(document).get(0).getMessage());
-        //assertEquals("Need whitespace before symbol \"(\".", errors.get(document).get(1).getMessage());
+        assertEquals(asList("Need whitespace after symbol \")\".", "Need whitespace before symbol \"(\"."),
+          errors.get(document).stream().map(ValidationError::getMessage).sorted().collect(toList()));
     }
 
     @Test

--- a/redpen-server/src/main/java/cc/redpen/server/api/CORSFilter.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/CORSFilter.java
@@ -1,0 +1,33 @@
+package cc.redpen.server.api;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Allows CORS (Cross-Origin AJAX requests), so that RedPen API can be used from a different domain
+ */
+public class CORSFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest)servletRequest;
+        HttpServletResponse response = (HttpServletResponse)servletResponse;
+        String origin = request.getHeader("Origin");
+        if (origin != null) {
+            response.addHeader("Access-Control-Allow-Origin", origin);
+            response.addHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept");
+            response.setHeader("Access-Control-Max-Age", "1728000");
+
+            if (request.getMethod().equals("OPTIONS")) return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override public void destroy() {
+    }
+
+    @Override public void init(FilterConfig filterConfig) throws ServletException {
+    }
+}

--- a/redpen-server/src/main/webapp/WEB-INF/web.xml
+++ b/redpen-server/src/main/webapp/WEB-INF/web.xml
@@ -26,4 +26,14 @@
         <servlet-name>restSdkService</servlet-name>
         <url-pattern>/rest/*</url-pattern>
     </servlet-mapping>
+
+    <filter>
+        <filter-name>CORSFilter</filter-name>
+        <filter-class>cc.redpen.server.api.CORSFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>CORSFilter</filter-name>
+        <url-pattern>/rest/*</url-pattern>
+    </filter-mapping>
 </web-app>

--- a/redpen-server/src/test/java/cc/redpen/server/api/CORSFilterTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/CORSFilterTest.java
@@ -1,0 +1,41 @@
+package cc.redpen.server.api;
+
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.*;
+
+public class CORSFilterTest {
+  CORSFilter filter = new CORSFilter();
+  HttpServletRequest request = mock(HttpServletRequest.class);
+  HttpServletResponse response = mock(HttpServletResponse.class);
+  FilterChain chain = mock(FilterChain.class);
+
+  @Test
+  public void doNothingForRegularRequests() throws Exception {
+    filter.doFilter(request, response, chain);
+    verify(response, never()).addHeader(anyString(), anyString());
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  public void addAllowOriginForCORSRequests() throws Exception {
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getHeader("Origin")).thenReturn("http://blah.com");
+    filter.doFilter(request, response, chain);
+    verify(response).addHeader("Access-Control-Allow-Origin", "http://blah.com");
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  public void doNotGenerateResponseForOPTIONSRequests() throws Exception {
+    when(request.getMethod()).thenReturn("OPTIONS");
+    when(request.getHeader("Origin")).thenReturn("http://blah.com");
+    filter.doFilter(request, response, chain);
+    verify(response).addHeader("Access-Control-Allow-Origin", "http://blah.com");
+    verify(chain, never()).doFilter(request, response);
+  }
+}


### PR DESCRIPTION
so that RedPen API can be used from a different domain - allows for a proxy-less communication with RedPen Server from WordPress Plugin