### PR TITLE
Improve RedPen custom resource loading

### DIFF
--- a/redpen-cli/pom.xml
+++ b/redpen-cli/pom.xml
@@ -120,6 +120,11 @@
             <version>1.2</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -176,13 +176,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.6</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.pegdown</groupId>

--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -168,11 +168,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20080701</version>

--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -73,10 +73,10 @@ public class RedPen {
      */
     public RedPen(Configuration configuration) throws RedPenException {
         this.configuration = configuration;
-        this.sentenceExtractor = new SentenceExtractor(this.configuration.getSymbolTable());
+        this.sentenceExtractor = new SentenceExtractor(configuration.getSymbolTable());
         this.validators = new ArrayList<>();
         for (ValidatorConfiguration config : configuration.getValidatorConfigs()) {
-            validators.add(ValidatorFactory.getInstance(config, configuration.getSymbolTable()));
+            validators.add(ValidatorFactory.getInstance(config, configuration));
         }
 
     }
@@ -240,17 +240,12 @@ public class RedPen {
             return false;
 
         RedPen redPen = (RedPen) o;
-
-        if (configuration != null ? !configuration.equals(redPen.configuration) : redPen.configuration != null)
-            return false;
-
-        return true;
+        return Objects.equals(configuration, redPen.configuration);
     }
 
     @Override
     public int hashCode() {
-        int result = configuration != null ? configuration.hashCode() : 0;
-        return result;
+        return configuration != null ? configuration.hashCode() : 0;
     }
 
     @Override

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -129,7 +129,7 @@ public class Configuration implements Serializable, Cloneable {
     }
 
     /**
-     * Finds file relative to either working directory or $REDPEN_HOME
+     * Finds file relative to either working directory, base directory or $REDPEN_HOME
      * @param relativePath of file to find
      * @return resolved file if it exists
      * @throws RedPenException if file doesn't exist in either place
@@ -146,8 +146,8 @@ public class Configuration implements Serializable, Cloneable {
         file = new File(home, relativePath);
         if (file.exists()) return file;
 
-        throw new RedPenException(String.format("%s is not under $REDPEN_HOME(%s) or current directory(%s).",
-          relativePath, home.getAbsolutePath(), new File("").getAbsoluteFile()));
+        throw new RedPenException(String.format("%s is not under working directory (%s)" + (base != null ? ", base (" + base + ")" : "")  + " or $REDPEN_HOME (%s).",
+          relativePath, new File("").getAbsoluteFile(), home.getAbsolutePath()));
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -152,6 +152,14 @@ public class Configuration implements Serializable, Cloneable {
           '}';
     }
 
+    public static ConfigurationBuilder builder() {
+        return new ConfigurationBuilder();
+    }
+
+    public static ConfigurationBuilder builder(String lang) {
+        return new ConfigurationBuilder().setLanguage(lang);
+    }
+
     /**
      * Builder class of Configuration.
      */

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -143,6 +143,15 @@ public class Configuration implements Serializable, Cloneable {
         return getKey().hashCode();
     }
 
+    @Override public String toString() {
+        return "Configuration{" +
+          "lang='" + lang + '\'' +
+          ", tokenizer=" + tokenizer +
+          ", validatorConfigs=" + validatorConfigs +
+          ", symbolTable=" + symbolTable +
+          '}';
+    }
+
     /**
      * Builder class of Configuration.
      */

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -115,10 +115,17 @@ public class Configuration implements Serializable, Cloneable {
     }
 
     /**
-     * @return RedPen home directory, relative to which many custom resources are evaluated
+     * @return RedPen home directory, relative to which custom resources are evaluated
      */
     public File getHome() {
         return home;
+    }
+
+    /**
+     * @return RedPen configuration base directory, relative to which custom resources are evaluated
+     */
+    public File getBase() {
+        return base;
     }
 
     /**
@@ -131,8 +138,10 @@ public class Configuration implements Serializable, Cloneable {
         File file = new File(relativePath);
         if (file.exists()) return file;
 
-        file = new File(base, relativePath);
-        if (file.exists()) return file;
+        if (base != null) {
+            file = new File(base, relativePath);
+            if (file.exists()) return file;
+        }
 
         file = new File(home, relativePath);
         if (file.exists()) return file;

--- a/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
@@ -39,8 +39,7 @@ import static cc.redpen.config.Configuration.ConfigurationBuilder;
  * Load the central configuration of {@link cc.redpen.RedPen}.
  */
 public class ConfigurationLoader {
-    private static final Logger LOG =
-            LoggerFactory.getLogger(ConfigurationLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLoader.class);
     private ConfigurationBuilder configBuilder = new ConfigurationBuilder();
 
     private static Symbol createSymbol(Element element) throws RedPenException {
@@ -89,7 +88,7 @@ public class ConfigurationLoader {
     public Configuration load(File configFile) throws RedPenException {
         LOG.info("Loading config from specified config file: \"{}\"", configFile.getAbsolutePath());
         try (InputStream fis = new FileInputStream(configFile)) {
-            return this.load(fis);
+            return this.load(fis, configFile.getParentFile());
         } catch (IOException e) {
             throw new RedPenException(e);
         }
@@ -127,9 +126,22 @@ public class ConfigurationLoader {
      * @throws cc.redpen.RedPenException when failed to load configuration from specified stream
      */
     public Configuration load(InputStream stream) throws RedPenException {
+        return load(stream, null);
+    }
+
+    /**
+     * load {@link cc.redpen.RedPen} configuration.
+     * Provided stream will be closed.
+     *
+     * @param stream input configuration settings
+     * @param base base dir for resolving of relative resources
+     * @return Configuration loaded from input stream
+     * @throws cc.redpen.RedPenException when failed to load configuration from specified stream
+     */
+    public Configuration load(InputStream stream, File base) throws RedPenException {
         Document doc = toDocument(stream);
 
-        configBuilder = new ConfigurationBuilder();
+        configBuilder = new ConfigurationBuilder().setBaseDir(base);
         Element rootElement = getRootNode(doc, "redpen-conf");
 
         String language = rootElement.getAttribute("lang");

--- a/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
@@ -102,8 +102,20 @@ public class ConfigurationLoader {
      * @throws cc.redpen.RedPenException when failed to load configuration from specified resource
      */
     public Configuration loadFromResource(String resourcePath) throws RedPenException {
+        return loadFromResource(resourcePath, null);
+    }
+
+    /**
+     * load {@link cc.redpen.RedPen} settings.
+     *
+     * @param resourcePath input configuration path
+     * @param base base dir for resolving of relative resources
+     * @return Validator configuration resources
+     * @throws cc.redpen.RedPenException when failed to load configuration from specified resource
+     */
+    public Configuration loadFromResource(String resourcePath, File base) throws RedPenException {
         InputStream inputConfigStream = Configuration.class.getResourceAsStream(resourcePath);
-        return load(inputConfigStream);
+        return load(inputConfigStream, base);
     }
 
     /**
@@ -114,7 +126,19 @@ public class ConfigurationLoader {
      * @throws cc.redpen.RedPenException when failed to load Configuration from specified string
      */
     public Configuration loadFromString(String configString) throws RedPenException {
-        return load(new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8)));
+        return loadFromString(configString, null);
+    }
+
+    /**
+     * load {@link cc.redpen.RedPen} settings.
+     *
+     * @param configString configuration as String
+     * @param base base dir for resolving of relative resources
+     * @return Validator configuration resources
+     * @throws cc.redpen.RedPenException when failed to load Configuration from specified string
+     */
+    public Configuration loadFromString(String configString, File base) throws RedPenException {
+        return load(new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8)), base);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
+++ b/redpen-core/src/main/java/cc/redpen/config/SymbolTable.java
@@ -171,9 +171,8 @@ public class SymbolTable implements Serializable, Cloneable {
     public String toString() {
         return "SymbolTable{" +
                 "symbolDictionary=" + symbolDictionary +
-                ", valueDictionary=" + valueDictionary +
-                ", type='" + variant + '\'' +
                 ", lang='" + lang + '\'' +
+                ", variant='" + variant + '\'' +
                 '}';
     }
 

--- a/redpen-core/src/main/java/cc/redpen/config/ValidatorConfiguration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/ValidatorConfiguration.java
@@ -104,7 +104,8 @@ public class ValidatorConfiguration implements Serializable, Cloneable {
         if (this == o) return true;
         if (!(o instanceof ValidatorConfiguration)) return false;
         ValidatorConfiguration that = (ValidatorConfiguration)o;
-        return Objects.equals(configurationName, that.configurationName);
+        return Objects.equals(configurationName, that.configurationName) &&
+               Objects.equals(attributes, that.attributes);
     }
 
     @Override public int hashCode() {

--- a/redpen-core/src/main/java/cc/redpen/model/Document.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Document.java
@@ -121,6 +121,14 @@ public class Document implements Iterable<Section>, Serializable {
                 '}';
     }
 
+    public static DocumentBuilder builder() {
+        return new DocumentBuilder();
+    }
+
+    public static DocumentBuilder builder(RedPenTokenizer tokenizer) {
+        return new DocumentBuilder(tokenizer);
+    }
+
     public static class DocumentBuilder {
         private final RedPenTokenizer tokenizer;
         boolean built = false;

--- a/redpen-core/src/main/java/cc/redpen/parser/LaTeXParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/LaTeXParser.java
@@ -46,7 +46,7 @@ class LaTeXParser extends BaseDocumentParser {
     @Override
     public Document parse(InputStream inputStream, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer)
             throws RedPenException {
-        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        Document.DocumentBuilder documentBuilder = Document.builder(tokenizer);
         fileName.ifPresent(documentBuilder::setFileName);
 
         StringBuilder sb = new StringBuilder();

--- a/redpen-core/src/main/java/cc/redpen/parser/MarkdownParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/MarkdownParser.java
@@ -55,7 +55,7 @@ class MarkdownParser extends BaseDocumentParser {
     @Override
     public Document parse(InputStream inputStream, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer)
             throws RedPenException {
-        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        Document.DocumentBuilder documentBuilder = Document.builder(tokenizer);
         fileName.ifPresent(documentBuilder::setFileName);
 
         StringBuilder sb = new StringBuilder();

--- a/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
@@ -49,7 +49,7 @@ final public class PlainTextParser extends BaseDocumentParser implements Seriali
     @Override
     public Document parse(InputStream is, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer)
             throws RedPenException {
-        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        Document.DocumentBuilder documentBuilder = Document.builder(tokenizer);
         fileName.ifPresent(documentBuilder::setFileName);
 
         List<Sentence> headers = new ArrayList<>();

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -56,7 +56,7 @@ public class SentenceExtractor {
      * @param fullStopList set of end of sentence characters
      */
     SentenceExtractor(char[] fullStopList) {
-        this(fullStopList, extractRightQuotations(new Configuration.ConfigurationBuilder().build().getSymbolTable()));
+        this(fullStopList, extractRightQuotations(Configuration.builder().build().getSymbolTable()));
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/parser/WikiParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/WikiParser.java
@@ -94,7 +94,7 @@ class WikiParser extends BaseDocumentParser {
     @Override
     public Document parse(InputStream is, Optional<String> filename, SentenceExtractor sentenceExtractor,
                           RedPenTokenizer tokenizer) throws RedPenException{
-        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        Document.DocumentBuilder documentBuilder = Document.builder(tokenizer);
         filename.ifPresent(documentBuilder::setFileName);
         BufferedReader br;
 

--- a/redpen-core/src/main/java/cc/redpen/parser/asciidoc/AsciiDocParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/asciidoc/AsciiDocParser.java
@@ -102,7 +102,7 @@ public class AsciiDocParser extends BaseDocumentParser {
 
     @Override
     public Document parse(InputStream inputStream, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer) throws RedPenException {
-        Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        Document.DocumentBuilder documentBuilder = Document.builder(tokenizer);
         fileName.ifPresent(documentBuilder::setFileName);
 
         Model model = new Model(sentenceExtractor);

--- a/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
@@ -89,23 +89,19 @@ public class DictionaryLoader<E> {
      *
      * @param path           resource path
      * @param dictionaryName name of the resource
-     * @return word list
-     * @throws RedPenException when failed to load the dictionary
+     * @return word collection or empty if resource is missing
      */
-    public E loadCachedFromResource(String path, String dictionaryName) throws RedPenException {
-        E strings = resourceCache.computeIfAbsent(path, e -> {
+    public E loadCachedFromResource(String path, String dictionaryName) {
+        return resourceCache.computeIfAbsent(path, e -> {
             try {
-                return loadFromResource(path);
+                E result = loadFromResource(path);
+                LOG.info("Succeeded to load " + dictionaryName + ".");
+                return result;
             } catch (IOException ioe) {
-                LOG.error(ioe.getMessage());
-                return null;
+                LOG.error("Failed to load " + dictionaryName + ":" + path + ": " + ioe.getMessage());
+                return supplier.get();
             }
         });
-        if (strings == null) {
-            throw new RedPenException("Failed to load " + dictionaryName + ":" + path);
-        }
-        LOG.info("Succeeded to load " + dictionaryName + ".");
-        return strings;
     }
 
 

--- a/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/util/DictionaryLoader.java
@@ -118,7 +118,6 @@ public class DictionaryLoader<E> {
      */
     public E loadCachedFromFile(File file, String dictionaryName) throws RedPenException {
         String path = file.getAbsolutePath();
-        ensureFileIsInsideRedPenHomeOrWorkingDirectory(path);
         if (!file.exists()) {
             throw new RedPenException("File not found: " + file);
         }
@@ -149,36 +148,5 @@ public class DictionaryLoader<E> {
         }
         LOG.info("Succeeded to load " + dictionaryName + ".");
         return loaded;
-    }
-
-    /**
-     * Test the specified path is inside $REDPEN_HOME, or JVM working directory. If not, throw RedPenException
-     *
-     * @param path path to test
-     * @throws RedPenException the specified path is not inside $REDPEN_HOME
-     */
-    public static void ensureFileIsInsideRedPenHomeOrWorkingDirectory(String path) throws RedPenException {
-            try {
-                String canonicalPath = new File(path).getCanonicalPath();
-                String currentDirectory = new File("").getCanonicalPath();
-                if (canonicalPath.startsWith(currentDirectory)) {
-                    return;
-                }
-                String home = System.getProperty("REDPEN_HOME", System.getenv("REDPEN_HOME"));
-                String homeCanonicalPath;
-                if (home != null) {
-                    homeCanonicalPath = new File(home).getCanonicalPath();
-                    if (canonicalPath.startsWith(homeCanonicalPath)) {
-                        return;
-                    }
-                }else{
-                    homeCanonicalPath = "not specified";
-                }
-                throw new RedPenException(String.format("%s  is not under $REDPEN_HOME(%s) or current directory(%s).",
-                        canonicalPath , homeCanonicalPath, currentDirectory));
-
-            } catch (IOException e) {
-                throw new RedPenException(e);
-            }
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/util/SpellingUtils.java
+++ b/redpen-core/src/main/java/cc/redpen/util/SpellingUtils.java
@@ -37,14 +37,8 @@ public class SpellingUtils {
     protected static void loadDictionary(String lang) {
         if (dictionaries.get(lang) == null) {
             String defaultDictionaryFile = DEFAULT_RESOURCE_PATH + "/spellchecker-" + lang + ".dat";
-            Set<String> dictionary;
-            try {
-                dictionary = new DictionaryLoader<HashSet<String>>(
-                        HashSet::new, (set, line) -> set.add(line.toLowerCase())
-                ).loadCachedFromResource(defaultDictionaryFile, "spell dictionary");
-            } catch (Exception e) {
-                dictionary = new HashSet<>();
-            }
+            Set<String> dictionary = new DictionaryLoader<Set<String>>(HashSet::new, (set, line) -> set.add(line.toLowerCase()))
+              .loadCachedFromResource(defaultDictionaryFile, "spell dictionary");
             dictionaries.put(lang, Collections.unmodifiableSet(dictionary));
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -22,7 +22,6 @@ import cc.redpen.model.Document;
 import cc.redpen.model.Section;
 import cc.redpen.model.Sentence;
 import cc.redpen.tokenizer.TokenElement;
-import cc.redpen.util.DictionaryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,16 +62,12 @@ public class JavaScriptValidator extends Validator {
 
     @Override
     protected void init() throws RedPenException {
-        String home = System.getProperty("REDPEN_HOME", System.getenv("REDPEN_HOME"));
-        home = home != null ? home : ".";
-
-        String jsValidatorsPath = getConfigAttribute("script-path").orElse(home + File.separator + DEFAULT_JS_VALIDATORS_PATH);
-        File jsDirectory = new File(jsValidatorsPath);
-        if(!jsDirectory.exists()){
+        Optional<String> jsValidatorsPath = getConfigAttribute("script-path");
+        File jsDirectory = findFile(jsValidatorsPath.orElse(DEFAULT_JS_VALIDATORS_PATH));
+        if (!jsDirectory.exists()) {
             LOG.info("JavaScript validators directory is missing: {}", jsValidatorsPath);
-        }else {
+        } else {
             LOG.info("JavaScript validators directory: {}", jsValidatorsPath);
-            DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(jsValidatorsPath);
             File[] jsValidatorFiles = jsDirectory.listFiles();
             if (jsValidatorFiles != null) {
                 for (File file : jsValidatorFiles) {

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -63,10 +63,8 @@ public class JavaScriptValidator extends Validator {
     @Override
     protected void init() throws RedPenException {
         Optional<String> jsValidatorsPath = getConfigAttribute("script-path");
-        File jsDirectory = findFile(jsValidatorsPath.orElse(DEFAULT_JS_VALIDATORS_PATH));
-        if (!jsDirectory.exists()) {
-            LOG.info("JavaScript validators directory is missing: {}", jsValidatorsPath);
-        } else {
+        try {
+            File jsDirectory = findFile(jsValidatorsPath.orElse(DEFAULT_JS_VALIDATORS_PATH));
             LOG.info("JavaScript validators directory: {}", jsValidatorsPath);
             File[] jsValidatorFiles = jsDirectory.listFiles();
             if (jsValidatorFiles != null) {
@@ -80,6 +78,9 @@ public class JavaScriptValidator extends Validator {
                     }
                 }
             }
+        }
+        catch (RedPenException e) {
+            LOG.warn("JavaScript validators directory is missing: {}", e.toString());
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -19,6 +19,7 @@ package cc.redpen.validator;
 
 
 import cc.redpen.RedPenException;
+import cc.redpen.config.Configuration;
 import cc.redpen.config.SymbolTable;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Document;
@@ -31,6 +32,7 @@ import cc.redpen.util.RuleExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -44,7 +46,7 @@ public abstract class Validator {
 
     private ResourceBundle errorMessages = null;
     private ValidatorConfiguration config;
-    private SymbolTable symbolTable;
+    private Configuration globalConfig;
 
     public Validator() {
         setLocale(Locale.getDefault());
@@ -111,9 +113,9 @@ public abstract class Validator {
         return Collections.emptyList();
     }
 
-    final void preInit(ValidatorConfiguration config, SymbolTable symbolTable) throws RedPenException {
+    final void preInit(ValidatorConfiguration config, Configuration globalConfig) throws RedPenException {
         this.config = config;
-        this.symbolTable = symbolTable;
+        this.globalConfig = globalConfig;
         init();
     }
 
@@ -197,7 +199,11 @@ public abstract class Validator {
     }
 
     protected SymbolTable getSymbolTable() {
-        return symbolTable;
+        return globalConfig.getSymbolTable();
+    }
+
+    protected File findFile(String relativePath) throws RedPenException {
+        return globalConfig.findFile(relativePath);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
@@ -19,7 +19,6 @@ package cc.redpen.validator;
 
 import cc.redpen.RedPenException;
 import cc.redpen.config.Configuration;
-import cc.redpen.config.SymbolTable;
 import cc.redpen.config.ValidatorConfiguration;
 
 import java.lang.reflect.Constructor;
@@ -50,14 +49,13 @@ public class ValidatorFactory {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration(validatorName))
                 .build();
-        return getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        return getInstance(conf.getValidatorConfigs().get(0), conf);
     }
 
     // store validator constructors to save reflection API call costs
     private static final Map<String, Constructor> validatorConstructorMap = new ConcurrentHashMap<>();
 
-    public static Validator getInstance(ValidatorConfiguration config, SymbolTable symbolTable)
-            throws RedPenException {
+    public static Validator getInstance(ValidatorConfiguration config, Configuration globalConfig) throws RedPenException {
         Constructor<?> constructor = validatorConstructorMap.computeIfAbsent(config.getValidatorClassName(), validatorClassName -> {
             try {
                 for (String validatorPackage : VALIDATOR_PACKAGES) {
@@ -85,7 +83,7 @@ public class ValidatorFactory {
         }
         try {
             Validator validator = (Validator) constructor.newInstance();
-            validator.preInit(config, symbolTable);
+            validator.preInit(config, globalConfig);
             return validator;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
@@ -47,8 +47,7 @@ public class ValidatorFactory {
     }
 
     public static Validator getInstance(String validatorName) throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration(validatorName))
                 .build();
         return getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());

--- a/redpen-core/src/main/java/cc/redpen/validator/section/WordFrequencyValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/WordFrequencyValidator.java
@@ -63,17 +63,12 @@ public class WordFrequencyValidator extends Validator {
 
         String defaultDictionaryFile = DEFAULT_RESOURCE_PATH + "/word-frequency-" + getSymbolTable().getLang() + ".dat";
         referenceWordDeviations = new HashMap<>();
-        try {
-            referenceWordFrequencies =
-                    new DictionaryLoader<Map<String, Double>>(HashMap::new, (set, line) -> {
-                        String[] fields = line.split(" ");
-                        set.put(fields[1], Double.valueOf(fields[0]));
-                    }).loadCachedFromResource(defaultDictionaryFile, "word frequencies");
-            referenceStdDeviation = getDeviations(referenceWordFrequencies, referenceWordDeviations);
-
-        } catch (Exception ignored) {
-            referenceWordFrequencies = new HashMap<>();
-        }
+        referenceWordFrequencies =
+                new DictionaryLoader<Map<String, Double>>(HashMap::new, (set, line) -> {
+                    String[] fields = line.split(" ");
+                    set.put(fields[1], Double.valueOf(fields[0]));
+                }).loadCachedFromResource(defaultDictionaryFile, "word frequencies");
+        referenceStdDeviation = getDeviations(referenceWordFrequencies, referenceWordDeviations);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubleNegativeValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubleNegativeValidator.java
@@ -25,10 +25,11 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
+import static java.util.Arrays.asList;
 
 /**
  * Detect double negative expressions in Japanese texts.
@@ -82,6 +83,6 @@ public class DoubleNegativeValidator extends Validator {
 
     @Override
     public List<String> getSupportedLanguages() {
-        return Arrays.asList(Locale.JAPANESE.getLanguage(), Locale.ENGLISH.getLanguage());
+        return asList(Locale.JAPANESE.getLanguage(), Locale.ENGLISH.getLanguage());
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledWordValidator.java
@@ -24,7 +24,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -70,7 +69,7 @@ final public class DoubledWordValidator extends Validator {
 
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
-            customSkipList.addAll(WORD_LIST.loadCachedFromFile(new File(confFile.get()), "DoubledWordValidator user dictionary"));
+            customSkipList.addAll(WORD_LIST.loadCachedFromFile(findFile(confFile.get()), "DoubledWordValidator user dictionary"));
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidExpressionValidator.java
@@ -23,7 +23,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
@@ -71,7 +70,7 @@ final public class InvalidExpressionValidator extends Validator {
 
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
-            customInvalidExpressions.addAll(WORD_LIST.loadCachedFromFile(new File(confFile.get()), "InvalidExpressionValidator user dictionary"));
+            customInvalidExpressions.addAll(WORD_LIST.loadCachedFromFile(findFile(confFile.get()), "InvalidExpressionValidator user dictionary"));
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidWordValidator.java
@@ -24,13 +24,7 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Detect invalid word occurrences.
@@ -74,7 +68,7 @@ final public class InvalidWordValidator extends Validator {
 
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
-            customInvalidWords.addAll(WORD_LIST.loadCachedFromFile(new File(confFile.get()), "InvalidWordValidator user dictionary"));
+            customInvalidWords.addAll(WORD_LIST.loadCachedFromFile(findFile(confFile.get()), "InvalidWordValidator user dictionary"));
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
@@ -24,13 +24,7 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Validate the end hyphens of Katakana words in Japanese documents.
@@ -121,7 +115,7 @@ final public class KatakanaEndHyphenValidator extends Validator {
 
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
-            customSkipList.addAll(WORD_LIST.loadCachedFromFile(new File(confFile.get()), "KatakanaEndHyphenValidator user dictionary"));
+            customSkipList.addAll(WORD_LIST.loadCachedFromFile(findFile(confFile.get()), "KatakanaEndHyphenValidator user dictionary"));
         }
     }
 
@@ -137,8 +131,7 @@ final public class KatakanaEndHyphenValidator extends Validator {
 
     @Override
     public int hashCode() {
-        int result = customSkipList != null ? customSkipList.hashCode() : 0;
-        return result;
+        return customSkipList != null ? customSkipList.hashCode() : 0;
     }
 
     @Override

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
@@ -25,7 +25,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.*;
 
 /**
@@ -172,7 +171,7 @@ final public class KatakanaSpellCheckValidator extends Validator {
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
             LOG.info("User defined Katakana word dictionary found.");
-            customExceptions.addAll(WORD_LIST.loadCachedFromFile(new File(confFile.get()),
+            customExceptions.addAll(WORD_LIST.loadCachedFromFile(findFile(confFile.get()),
                     "KatakanaSpellCheckValidator user dictionary"));
             LOG.info("Succeeded to add elements of user defined dictionary.");
         }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
@@ -165,8 +165,7 @@ final public class KatakanaSpellCheckValidator extends Validator {
     protected void init() throws RedPenException {
         boolean disableDefault = getConfigAttributeAsBoolean("disable-default", false);
         if (!disableDefault) {
-            String defaultDictionaryFile = DEFAULT_RESOURCE_PATH
-                    + "/katakana-spellcheck.dat";
+            String defaultDictionaryFile = DEFAULT_RESOURCE_PATH + "/katakana-spellcheck.dat";
             exceptions = WORD_LIST.loadCachedFromResource(defaultDictionaryFile, "katakana word dictionary");
         }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
@@ -25,7 +25,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
@@ -57,7 +56,7 @@ public class SpellingValidator extends Validator {
         Optional<String> userDictionaryFile = getConfigAttribute("dict");
         if (userDictionaryFile.isPresent()) {
             String f = userDictionaryFile.get();
-            customDictionary.addAll(WORD_LIST_LOWERCASED.loadCachedFromFile(new File(f), "SpellingValidator user dictionary"));
+            customDictionary.addAll(WORD_LIST_LOWERCASED.loadCachedFromFile(findFile(f), "SpellingValidator user dictionary"));
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidator.java
@@ -24,7 +24,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.*;
 
 /**
@@ -82,7 +81,7 @@ final public class StartWithCapitalLetterValidator extends Validator {
 
         Optional<String> confFile = getConfigAttribute("dict");
         if (confFile.isPresent()) {
-            customWhiteList = WORD_LIST.loadCachedFromFile(new File(confFile.get()), "StartWithCapitalLetterValidator user dictionary");
+            customWhiteList = WORD_LIST.loadCachedFromFile(findFile(confFile.get()), "StartWithCapitalLetterValidator user dictionary");
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidator.java
@@ -25,12 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Check if the input sentence start with a capital letter.
@@ -82,9 +77,7 @@ final public class StartWithCapitalLetterValidator extends Validator {
 
     @Override
     protected void init() throws RedPenException {
-
-        String defaultDictionaryFile = DEFAULT_RESOURCE_PATH
-                + "/default-capital-case-exception-list.dat";
+        String defaultDictionaryFile = DEFAULT_RESOURCE_PATH + "/default-capital-case-exception-list.dat";
         whiteList = WORD_LIST.loadCachedFromResource(defaultDictionaryFile, "capital letter exception dictionary");
 
         Optional<String> confFile = getConfigAttribute("dict");

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
@@ -23,7 +23,6 @@ import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -63,7 +62,7 @@ final public class SuggestExpressionValidator extends Validator {
             LOG.error("Dictionary file is not specified");
             throw new RedPenException("dictionary file is not specified");
         } else {
-            synonyms = KEY_VALUE.loadCachedFromFile(new File(confFile.get()), "SuggestExpressionValidator dictionary");
+            synonyms = KEY_VALUE.loadCachedFromFile(findFile(confFile.get()), "SuggestExpressionValidator dictionary");
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/WeakExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/WeakExpressionValidator.java
@@ -43,15 +43,8 @@ public class WeakExpressionValidator extends Validator {
         super.init();
 
         String defaultDictionaryFile = DEFAULT_RESOURCE_PATH + "/weak-expressions-" + getSymbolTable().getLang() + ".dat";
-        try {
-            weakExpressions =
-                    new DictionaryLoader<List<String>>(ArrayList::new, (list, line) -> {
-                        list.add(line.trim().toLowerCase());
-                    }).loadCachedFromResource(defaultDictionaryFile, "weak expressions");
-
-        } catch (Exception ignored) {
-            weakExpressions = new ArrayList<>();
-        }
+        weakExpressions = new DictionaryLoader<List<String>>(ArrayList::new, (list, line) -> list.add(line.trim().toLowerCase()))
+          .loadCachedFromResource(defaultDictionaryFile, "weak expressions");
     }
 
     /**

--- a/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
@@ -46,7 +46,7 @@ public class AsciiDocParserTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullDocument() throws Exception {
-        Configuration configuration = new Configuration.ConfigurationBuilder().build();
+        Configuration configuration = Configuration.builder().build();
         DocumentParser parser = DocumentParser.ASCIIDOC;
         InputStream is = null;
         parser.parse(is, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
@@ -130,7 +130,7 @@ public class AsciiDocParserTest {
         assertEquals(2, firstSection.getNumberOfParagraphs());
         assertEquals(0, firstSection.getNumberOfSubsections());
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
+        Configuration configuration = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Spelling"))
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
 
@@ -435,7 +435,7 @@ public class AsciiDocParserTest {
         Document doc = null;
         try {
             InputStream in = new FileInputStream(this.getClass().getClassLoader().getResource("asciidoc/" + filename).getFile());
-            Configuration configuration = new Configuration.ConfigurationBuilder().setLanguage(lang).build();
+            Configuration configuration = Configuration.builder().setLanguage(lang).build();
             doc = parser.parse(
                     in,
                     new SentenceExtractor(configuration.getSymbolTable()),
@@ -464,7 +464,7 @@ public class AsciiDocParserTest {
         DocumentParser parser = DocumentParser.ASCIIDOC;
         Document doc = null;
         try {
-            Configuration configuration = new Configuration.ConfigurationBuilder().build();
+            Configuration configuration = Configuration.builder().build();
             doc = parser.parse(
                     inputDocumentString,
                     new SentenceExtractor(configuration.getSymbolTable()),

--- a/redpen-core/src/test/java/cc/redpen/LaTeXParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/LaTeXParserTest.java
@@ -20,13 +20,11 @@ package cc.redpen;
 import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Document;
-import cc.redpen.model.ListBlock;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
 import cc.redpen.parser.DocumentParser;
 import cc.redpen.parser.LineOffset;
 import cc.redpen.parser.SentenceExtractor;
-import cc.redpen.parser.latex.LaTeXProcessor;
 import cc.redpen.validator.ValidationError;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,11 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static cc.redpen.config.SymbolType.COMMA;
-import static cc.redpen.config.SymbolType.FULL_STOP;
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
-import static cc.redpen.parser.latex.Tools.*;
+import static org.junit.Assert.assertNotNull;
 
 public class LaTeXParserTest {
 
@@ -539,7 +534,7 @@ public class LaTeXParserTest {
             + "大きなベッドタウンであり、多くの人が住んでいる。"
             + "\\end{document}\n";
         Configuration config =
-                new Configuration.ConfigurationBuilder().setLanguage("ja").build();
+                Configuration.builder("ja").build();
         Document doc = createFileContent(sampleText, config);
 
         Section firstSections = doc.getSection(0);
@@ -557,15 +552,12 @@ public class LaTeXParserTest {
             + "\\begin{document}\n"
             + "This is a good day。\n" // invalid end of sentence symbol
             + "\\end{document}\n";
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
+        Configuration conf = Configuration.builder().build();
         List<Document> documents = new ArrayList<>();
         documents.add(createFileContent(sampleText, conf));
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         RedPen redPen = new RedPen(configuration);
@@ -588,7 +580,7 @@ public class LaTeXParserTest {
     }
 
     private Document createFileContent(String inputDocumentString) {
-        Configuration conf = new Configuration.ConfigurationBuilder().build();
+        Configuration conf = Configuration.builder().build();
         DocumentParser parser = DocumentParser.LATEX;
         Document doc = null;
         try {

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import static cc.redpen.config.SymbolType.COMMA;
 import static cc.redpen.config.SymbolType.FULL_STOP;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 public class MarkdownParserTest {
 
@@ -49,7 +48,7 @@ public class MarkdownParserTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullDocument() throws Exception {
-        Configuration configuration = new Configuration.ConfigurationBuilder().build();
+        Configuration configuration = Configuration.builder().build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         InputStream is = null;
         parser.parse(is, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
@@ -815,7 +814,7 @@ public class MarkdownParserTest {
         sampleText += "わたしもお寿司が大好きです。\n";
         sampleText += "\n";
 
-        Document doc = createFileContent(sampleText, new Configuration.ConfigurationBuilder().setLanguage("ja").build());
+        Document doc = createFileContent(sampleText, Configuration.builder("ja").build());
 
         assertNotNull("doc is null", doc);
         assertEquals(2, doc.size());
@@ -844,8 +843,7 @@ public class MarkdownParserTest {
     public void testGenerateJapaneseDocument() {
         String sampleText = "埼玉は東京の北に存在する。";
         sampleText += "大きなベッドタウンであり、多くの人が住んでいる。";
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("ja").build();
+        Configuration conf = Configuration.builder("ja").build();
 
         Document doc = createFileContent(sampleText, conf);
         Section firstSections = doc.getSection(0);
@@ -857,8 +855,7 @@ public class MarkdownParserTest {
     public void testGenerateJapaneseWithMultipleSentencesInOneLine() {
         String sampleText = "それは異なる．たとえば，\\n" +
                 "以下のとおりである．";
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("ja")
+        Configuration conf = Configuration.builder("ja")
                 .addSymbol(new Symbol(FULL_STOP, '．', "."))
                 .addSymbol(new Symbol(COMMA, '，', "、"))
                 .build();
@@ -877,15 +874,12 @@ public class MarkdownParserTest {
     @Test
     public void testErrorPositionOfMarkdownParser() throws RedPenException {
         String sampleText = "This is a good day。\n"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
+        Configuration conf = Configuration.builder().build();
         List<Document> documents = new ArrayList<>();
         documents.add(createFileContent(sampleText, conf));
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         RedPen redPen = new RedPen(configuration);
@@ -900,15 +894,12 @@ public class MarkdownParserTest {
     @Test
     public void testInvalidSentenceInBlockquote() throws UnsupportedEncodingException, RedPenException {
         String sampleText = "> This is a good day。\n"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
+        Configuration conf = Configuration.builder().build();
         List<Document> documents = new ArrayList<>();
         documents.add(createFileContent(sampleText, conf));
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
         RedPen redPen = new RedPen(configuration);
         List<ValidationError> errors = redPen.validate(documents).get(documents.get(0));
@@ -931,7 +922,7 @@ public class MarkdownParserTest {
         DocumentParser parser = DocumentParser.MARKDOWN;
         Document doc = null;
         try {
-            Configuration configuration = new Configuration.ConfigurationBuilder().build();
+            Configuration configuration = Configuration.builder().build();
             doc = parser.parse(inputDocumentString, new SentenceExtractor(configuration.getSymbolTable()),
                     configuration.getTokenizer());
         } catch (RedPenException e) {

--- a/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
@@ -65,7 +65,7 @@ public class PlainTextParserTest {
 
     private Document generateDocument(String sampleText, String lang) {
         Document doc = null;
-        Configuration configuration = new Configuration.ConfigurationBuilder().setLanguage(lang).build();
+        Configuration configuration = Configuration.builder().setLanguage(lang).build();
 
         try {
             doc = parser.parse(sampleText, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
@@ -77,9 +77,8 @@ public class PlainTextParserTest {
 
     @Before
     public void setup() {
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
                 .build();
         parser = DocumentParser.PLAIN;
     }
@@ -325,18 +324,15 @@ public class PlainTextParserTest {
     @Test
     public void testErrorPositionOfPlainTextParser() throws RedPenException {
         String sampleText = "This is a good day。\n"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
+        Configuration conf = Configuration.builder().build();
         List<Document> documents = new ArrayList<>();
 
         DocumentParser parser = DocumentParser.PLAIN;
         Document doc = parser.parse(sampleText, new SentenceExtractor(conf.getSymbolTable()), conf.getTokenizer());
         documents.add(doc);
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         RedPen redPen = new RedPen(configuration);

--- a/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
@@ -77,9 +77,6 @@ public class PlainTextParserTest {
 
     @Before
     public void setup() {
-        Configuration configuration = Configuration.builder()
-                .addValidatorConfig(new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
-                .build();
         parser = DocumentParser.PLAIN;
     }
 

--- a/redpen-core/src/test/java/cc/redpen/RedPenTest.java
+++ b/redpen-core/src/test/java/cc/redpen/RedPenTest.java
@@ -57,7 +57,7 @@ public class RedPenTest {
                 .addSentence(new Sentence("One day while programming, he got a new idea.", 4))
                 .build());
 
-        Configuration configuration = new Configuration.ConfigurationBuilder().build();
+        Configuration configuration = Configuration.builder().build();
         RedPen redPen = new RedPen(configuration);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         Assert.assertEquals(0, errors.get(documents.get(0)).size());
@@ -183,18 +183,16 @@ public class RedPenTest {
     private RedPen getRedPenWithSentenceValidator() throws
             RedPenException {
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SentenceLength").addAttribute("max_len", "5"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SentenceLength").addAttribute("max_len", "5"))
                 .build();
         return new RedPen(configuration);
     }
 
     private RedPen getRedPenWithSectionValidator() throws
             RedPenException {
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SectionLength").addAttribute("max_num", "5"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SectionLength").addAttribute("max_num", "5"))
                 .build();
         return new RedPen(configuration);
     }

--- a/redpen-core/src/test/java/cc/redpen/RedPenTest.java
+++ b/redpen-core/src/test/java/cc/redpen/RedPenTest.java
@@ -46,7 +46,7 @@ public class RedPenTest {
     public void testEmptyValidator() throws RedPenException {
 
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("In a land far away, there once was as a hungry programmer.", 1))
@@ -68,7 +68,7 @@ public class RedPenTest {
     public void testSentenceValidatorWithSimpleDocument()
             throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .setFileName("tested file")
                 .addSection(0)
                 .addParagraph()
@@ -94,7 +94,7 @@ public class RedPenTest {
             throws RedPenException {
         List<Document> documents = new ArrayList<>();
 
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .setFileName("tested file")
                 .addSection(0)
                 .addSectionHeader("foobar")
@@ -118,7 +118,7 @@ public class RedPenTest {
     @Test
     public void testDocumentWithHeader() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .setFileName("tested file")
                 .addSection(0)
                 .addSectionHeader("this is it.")
@@ -142,7 +142,7 @@ public class RedPenTest {
     @Test
     public void testDocumentWithList() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .setFileName("tested file")
                 .addSection(0)
                 .addSectionHeader("this is it")
@@ -168,7 +168,7 @@ public class RedPenTest {
     @Test
     public void testDocumentWithoutContent() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .setFileName("tested file")
                 .build());
 

--- a/redpen-core/src/test/java/cc/redpen/SampleDocumentGenerator.java
+++ b/redpen-core/src/test/java/cc/redpen/SampleDocumentGenerator.java
@@ -40,10 +40,8 @@ public class SampleDocumentGenerator {
      * @param parser    document syntax: wiki, markdown or plain
      * @return DocumentCollection object
      */
-    public static List<Document> generateOneFileDocument(String docString,
-                                                             DocumentParser parser) throws RedPenException {
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .setLanguage("en").build();
+    public static List<Document> generateOneFileDocument(String docString, DocumentParser parser) throws RedPenException {
+        Configuration configuration = Configuration.builder().build();
         List<Document> docs = new ArrayList<>();
         docs.add(parser.parse(docString, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer()));
         return docs;

--- a/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
@@ -591,8 +591,7 @@ public class WikiParserTest {
         String sampleText = "埼玉は東京の北に存在する。";
         sampleText += "大きなベッドタウンであり、多くの人が住んでいる。";
 
-        Configuration config =
-                new Configuration.ConfigurationBuilder().setLanguage("ja").build();
+        Configuration config = Configuration.builder("ja").build();
         Document doc = createFileContent(sampleText, config);
 
         Section firstSections = doc.getSection(0);
@@ -603,15 +602,12 @@ public class WikiParserTest {
     @Test
     public void testErrorPositionOfMarkdownParser() throws RedPenException {
         String sampleText = "This is a good day。\n"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
+        Configuration conf = Configuration.builder().build();
         List<Document> documents = new ArrayList<>();
         documents.add(createFileContent(sampleText, conf));
 
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         RedPen redPen = new RedPen(configuration);
@@ -634,7 +630,7 @@ public class WikiParserTest {
     }
 
     private Document createFileContent(String inputDocumentString) {
-        Configuration conf = new Configuration.ConfigurationBuilder().build();
+        Configuration conf = Configuration.builder().build();
         DocumentParser parser = DocumentParser.WIKI;
         Document doc = null;
         try {

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationExporterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationExporterTest.java
@@ -20,21 +20,21 @@ public class ConfigurationExporterTest {
 
   @Test
   public void emptyConfig() throws Exception {
-    Configuration config = new Configuration.ConfigurationBuilder().build();
+    Configuration config = Configuration.builder().build();
     exporter.export(config, out);
     assertEquals("<redpen-conf lang=\"en\">\n</redpen-conf>", out.toString());
   }
 
   @Test
   public void emptyConfigForJapaneseLanguage() throws Exception {
-    Configuration config = new Configuration.ConfigurationBuilder().setLanguage("ja").build();
+    Configuration config = Configuration.builder("ja").build();
     exporter.export(config, out);
     assertEquals("<redpen-conf lang=\"ja\" variant=\"zenkaku\">\n</redpen-conf>", out.toString());
   }
 
   @Test
   public void validators() throws Exception {
-    Configuration config = new Configuration.ConfigurationBuilder()
+    Configuration config = Configuration.builder()
       .addValidatorConfig(new ValidatorConfiguration("Mega"))
       .addValidatorConfig(new ValidatorConfiguration("Super").addAttribute("hello", "world")).build();
     exporter.export(config, out);
@@ -51,7 +51,7 @@ public class ConfigurationExporterTest {
 
   @Test
   public void symbols() throws Exception {
-    Configuration config = new Configuration.ConfigurationBuilder()
+    Configuration config = Configuration.builder()
       .addSymbol(new Symbol(ASTERISK, 'X'))
       .addSymbol(new Symbol(COLON, ';', ":", false, true))
       .addSymbol(new Symbol(SEMICOLON, ':', ";&", true, false)).build();

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationLoaderTest.java
@@ -20,6 +20,10 @@ package cc.redpen.config;
 import cc.redpen.RedPenException;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
 import static cc.redpen.config.SymbolType.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -394,4 +398,14 @@ public class ConfigurationLoaderTest {
         new ConfigurationLoader().loadFromString(sampleConfigString);
     }
 
+    @Test
+    public void loadFromFileSetsBaseDir() throws Exception {
+        File file = File.createTempFile("redpen-conf", ".xml");
+        file.deleteOnExit();
+        try (OutputStream out = new FileOutputStream(file)) {
+            out.write("<redpen-conf/>".getBytes());
+        }
+        Configuration config = new ConfigurationLoader().load(file);
+        assertEquals(file.getParentFile(), config.getBase());
+    }
 }

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
@@ -28,10 +28,10 @@ import static org.junit.Assert.*;
 public class ConfigurationRedPenBuilderTest {
     @Test
     public void testBuildSimpleConfiguration() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
-                .setLanguage("en").build();
+                .build();
 
         assertEquals(2, config.getValidatorConfigs().size());
         assertNotNull(config.getSymbolTable());
@@ -43,7 +43,7 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationWithoutSymbolTable() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
@@ -57,7 +57,7 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationAddingProperties() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression")
                         .addAttribute("dict", "./foobar.dict"))
                 .addValidatorConfig(new ValidatorConfiguration("SentenceLength")
@@ -77,9 +77,8 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationSpecifyingLanguage() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja")
                 .build();
 
         assertNotNull(config.getSymbolTable());
@@ -89,9 +88,8 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationSpecifyingLanguageAndType() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja")
                 .setVariant("hankaku")
                 .build();
 
@@ -102,9 +100,8 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationOverrideSymbolSetting() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja")
                 .addSymbol(new Symbol(FULL_STOP, '.'))
                 .build();
 
@@ -115,9 +112,8 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationOverrideAddInvalidSymbolSetting() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja")
                 .addSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
                 .build();
 
@@ -130,9 +126,8 @@ public class ConfigurationRedPenBuilderTest {
 
     @Test
     public void testBuildConfigurationAccessingSymbolByValue() {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja")
                 .addSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
                 .build();
 
@@ -147,9 +142,8 @@ public class ConfigurationRedPenBuilderTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testBuildTwice(){
-        Configuration.ConfigurationBuilder builder = new Configuration.ConfigurationBuilder();
-        builder.setLanguage("en");
+    public void testBuildTwice() {
+        Configuration.ConfigurationBuilder builder = Configuration.builder();
         builder.build();
         // ConfigurationBuilder is not designed to build more than one RedPen instance
         builder.setLanguage("ja");

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -78,19 +78,19 @@ public class ConfigurationTest {
     @Test
     public void keyIsLangAndType() throws Exception {
         SymbolTable symbolTable = new SymbolTable("ja", Optional.of("hankaku"), emptyList());
-        assertEquals("ja.hankaku", new Configuration(symbolTable, emptyList(), "ja").getKey());
+        assertEquals("ja.hankaku", new Configuration(new File(""), symbolTable, emptyList(), "ja").getKey());
     }
 
     @Test
     public void keyIsLangOnlyIfTypeIsMissing() throws Exception {
         SymbolTable symbolTable = new SymbolTable("en", Optional.empty(), emptyList());
-        assertEquals("en", new Configuration(symbolTable, emptyList(), "en").getKey());
+        assertEquals("en", new Configuration(new File(""), symbolTable, emptyList(), "en").getKey());
     }
 
     @Test
     public void keyIsLangOnlyForZenkaku() throws Exception {
         SymbolTable symbolTable = new SymbolTable("ja", Optional.of("zenkaku"), emptyList());
-        assertEquals("ja", new Configuration(symbolTable, emptyList(), "ja").getKey());
+        assertEquals("ja", new Configuration(new File(""), symbolTable, emptyList(), "ja").getKey());
     }
 
     @Test
@@ -110,7 +110,12 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void findFileLooksInHomeDirectoryIfNotInWorkingOne() throws Exception {
+    public void findFileLooksInConfigBaseDirectorySecond() throws Exception {
+        assertEquals(new File("src/main"), Configuration.builder().setBaseDir(new File("src")).build().findFile("main"));
+    }
+
+    @Test
+    public void findFileLooksInRedPenHomeDirectoryThird() throws Exception {
         System.setProperty("REDPEN_HOME", "src");
         assertEquals(new File("src/main"), Configuration.builder().build().findFile("main"));
     }

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -98,8 +98,7 @@ public class ConfigurationTest {
 
     @Test
     public void canBeCloned() throws Exception {
-        Configuration conf = Configuration.builder()
-          .setLanguage("ja")
+        Configuration conf = Configuration.builder("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
@@ -118,8 +117,7 @@ public class ConfigurationTest {
 
     @Test
     public void equals() throws Exception {
-        Configuration conf = Configuration.builder()
-          .setLanguage("ja")
+        Configuration conf = Configuration.builder("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
@@ -137,8 +135,7 @@ public class ConfigurationTest {
 
     @Test
     public void serializable() throws Exception {
-        Configuration conf = Configuration.builder()
-          .setLanguage("ja")
+        Configuration conf = Configuration.builder("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -95,6 +95,7 @@ public class ConfigurationTest {
 
     @Test
     public void homeIsWorkingDirectoryByDefault() throws Exception {
+        System.clearProperty("REDPEN_HOME");
         assertEquals(new File(""), Configuration.builder().build().getHome());
     }
 
@@ -106,7 +107,8 @@ public class ConfigurationTest {
 
     @Test
     public void findFileLooksInWorkingDirectoryFirst() throws Exception {
-        assertEquals(new File("src"), Configuration.builder().build().findFile("src"));
+        String localFile = new File(".").list()[0];
+        assertEquals(new File(localFile), Configuration.builder().build().findFile(localFile));
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -17,6 +17,7 @@
  */
 package cc.redpen.config;
 
+import cc.redpen.RedPenException;
 import org.junit.Test;
 
 import java.io.*;
@@ -120,6 +121,30 @@ public class ConfigurationTest {
     public void findFileLooksInRedPenHomeDirectoryThird() throws Exception {
         System.setProperty("REDPEN_HOME", "src");
         assertEquals(new File("src/main"), Configuration.builder().build().findFile("main"));
+    }
+
+    @Test
+    public void findFileFailsIfFileNotFound() throws Exception {
+        try {
+            System.setProperty("REDPEN_HOME", "src");
+            Configuration.builder().build().findFile("hello.xml");
+            fail("Expecting RedPenException");
+        }
+        catch (RedPenException e) {
+            assertEquals("hello.xml is not under working directory (" + new File("").getAbsoluteFile() + ") or $REDPEN_HOME (" + new File("src").getAbsoluteFile() + ").", e.getMessage());
+        }
+    }
+
+    @Test
+    public void findFileFailsIfFileNotFound_basePathPresent() throws Exception {
+        try {
+            System.setProperty("REDPEN_HOME", "src");
+            Configuration.builder().setBaseDir(new File("some/base/dir")).build().findFile("hello.xml");
+            fail("Expecting RedPenException");
+        }
+        catch (RedPenException e) {
+            assertEquals("hello.xml is not under working directory (" + new File("").getAbsoluteFile() + "), base (some/base/dir) or $REDPEN_HOME (" + new File("src").getAbsoluteFile() + ").", e.getMessage());
+        }
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -36,8 +36,7 @@ public class ConfigurationTest {
 
     @Test
     public void testSentenceValidatorConfiguration() throws Exception {
-
-        Configuration configuration = new Configuration.ConfigurationBuilder()
+        Configuration configuration = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
@@ -57,7 +56,7 @@ public class ConfigurationTest {
         // NOTE: not throw a exception even when adding a non exist validator.
         // The errors occurs when creating the added non existing validator instance.
         try {
-            new Configuration.ConfigurationBuilder()
+            Configuration.builder()
                     .addValidatorConfig(new ValidatorConfiguration("ThereIsNoSuchValidator")).build();
         } catch (Exception e) {
             fail();
@@ -66,7 +65,7 @@ public class ConfigurationTest {
 
     @Test
     public void testSectionValidatorConfiguration() throws Exception {
-        Configuration configuration = new Configuration.ConfigurationBuilder().addValidatorConfig(new ValidatorConfiguration("SectionLength"))
+        Configuration configuration = Configuration.builder().addValidatorConfig(new ValidatorConfiguration("SectionLength"))
                 .addValidatorConfig(new ValidatorConfiguration("MaxParagraphNumber"))
                 .addValidatorConfig(new ValidatorConfiguration("ParagraphStartWith")).build();
         assertEquals(3, configuration.getValidatorConfigs().size());
@@ -74,7 +73,7 @@ public class ConfigurationTest {
 
     @Test
     public void testSymbolTableWithoutLanguageSetting() throws Exception {
-        Configuration configuration = new Configuration.ConfigurationBuilder().build(); // NOTE: load "en" setting when lang is not specified
+        Configuration configuration = Configuration.builder().build(); // NOTE: load "en" setting when lang is not specified
         assertEquals("en", configuration.getLang());
         assertNotNull(configuration.getLang());
     }
@@ -99,7 +98,7 @@ public class ConfigurationTest {
 
     @Test
     public void canBeCloned() throws Exception {
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
           .setLanguage("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
@@ -119,7 +118,7 @@ public class ConfigurationTest {
 
     @Test
     public void equals() throws Exception {
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
           .setLanguage("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
@@ -138,7 +137,7 @@ public class ConfigurationTest {
 
     @Test
     public void serializable() throws Exception {
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
           .setLanguage("ja")
           .setVariant("hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -19,10 +19,7 @@ package cc.redpen.config;
 
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.util.Optional;
 
 import static cc.redpen.config.SymbolType.AMPERSAND;
@@ -94,6 +91,28 @@ public class ConfigurationTest {
     public void keyIsLangOnlyForZenkaku() throws Exception {
         SymbolTable symbolTable = new SymbolTable("ja", Optional.of("zenkaku"), emptyList());
         assertEquals("ja", new Configuration(symbolTable, emptyList(), "ja").getKey());
+    }
+
+    @Test
+    public void homeIsWorkingDirectoryByDefault() throws Exception {
+        assertEquals(new File(""), Configuration.builder().build().getHome());
+    }
+
+    @Test
+    public void homeIsResolvedFromSystemPropertyOrEnvironment() throws Exception {
+        System.setProperty("REDPEN_HOME", "/foo");
+        assertEquals(new File("/foo"), Configuration.builder().build().getHome());
+    }
+
+    @Test
+    public void findFileLooksInWorkingDirectoryFirst() throws Exception {
+        assertEquals(new File("src"), Configuration.builder().build().findFile("src"));
+    }
+
+    @Test
+    public void findFileLooksInHomeDirectoryIfNotInWorkingOne() throws Exception {
+        System.setProperty("REDPEN_HOME", "src");
+        assertEquals(new File("src/main"), Configuration.builder().build().findFile("main"));
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/config/ValidatorConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ValidatorConfigurationTest.java
@@ -2,8 +2,7 @@ package cc.redpen.config;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.*;
 
 public class ValidatorConfigurationTest {
 
@@ -17,5 +16,26 @@ public class ValidatorConfigurationTest {
 
     assertNotSame(conf.getAttributes(), clone.getAttributes());
     assertEquals(conf.getAttributes(), clone.getAttributes());
+  }
+
+  @Test
+  public void equals() throws Exception {
+    ValidatorConfiguration conf = new ValidatorConfiguration("test").addAttribute("foo", "bar");
+    ValidatorConfiguration conf2 = new ValidatorConfiguration("test").addAttribute("foo", "bar");
+    assertEquals(conf, conf2);
+  }
+
+  @Test
+  public void equals_attributes() throws Exception {
+    ValidatorConfiguration conf = new ValidatorConfiguration("test").addAttribute("foo", "bar");
+    ValidatorConfiguration conf2 = new ValidatorConfiguration("test").addAttribute("foo", "bar2");
+    assertFalse(conf.equals(conf2));
+  }
+
+  @Test
+  public void equals_names() throws Exception {
+    ValidatorConfiguration conf = new ValidatorConfiguration("test");
+    ValidatorConfiguration conf2 = new ValidatorConfiguration("test2");
+    assertFalse(conf.equals(conf2));
   }
 }

--- a/redpen-core/src/test/java/cc/redpen/formatter/FormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/FormatterTest.java
@@ -50,7 +50,7 @@ public class FormatterTest extends Validator {
         setErrorList(errors);
         addLocalizedError(new Sentence("sentence", 1));
         Map<Document, List<ValidationError>> docErrorsMap = new HashMap<>();
-        Document document = new Document.DocumentBuilder().build();
+        Document document = Document.builder().build();
         docErrorsMap.put(document, errors);
         String result = formatter.format(docErrorsMap);
         Pattern p = Pattern.compile("foobar");

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
@@ -54,12 +54,9 @@ public class JSONBySentenceFormatterTest extends Validator {
     @Test
     public void testFormatErrorsFromMarkdownParser() throws RedPenException, JSONException {
         String sampleText = "This is a good day。"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration conf = Configuration.builder().build();
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
@@ -29,7 +29,7 @@ public class JSONBySentenceFormatterTest extends Validator {
         List<ValidationError> errors = new ArrayList<>();
         setErrorList(errors);
         addLocalizedError(new Sentence("testing JSONFormatter", 1));
-        Document document = new Document.DocumentBuilder().setFileName("docName").build();
+        Document document = Document.builder().setFileName("docName").build();
         String result = formatter.format(document, errors);
 
         JSONObject jsonObject = new JSONObject(result);

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
@@ -48,7 +48,7 @@ public class JSONFormatterTest extends Validator {
         List<ValidationError> errors = new ArrayList<>();
         setErrorList(errors);
         addLocalizedError(new Sentence("testing JSONFormatter", 1));
-        Document document = new Document.DocumentBuilder().setFileName("docName").build();
+        Document document = Document.builder().setFileName("docName").build();
         String result = formatter.format(document, errors);
         JSONObject jsonObject = new JSONObject(result);
         String docName = jsonObject.getString("document");
@@ -68,7 +68,7 @@ public class JSONFormatterTest extends Validator {
         List<ValidationError> errors = new ArrayList<>();
         setErrorList(errors);
         addLocalizedError(new Sentence("testing JSONFormatter", 1));
-        Document document = new Document.DocumentBuilder().setFileName("docName").build();
+        Document document = Document.builder().setFileName("docName").build();
         Map<Document, List<ValidationError>> documentListMap = new HashMap<>();
         documentListMap.put(document, errors);
 

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
@@ -91,12 +91,9 @@ public class JSONFormatterTest extends Validator {
     @Test
     public void testFormatDocumentsAndErrorsWithPosition() throws RedPenException, JSONException {
         String sampleText = "This is a good day。"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration conf = Configuration.builder().build();
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/formatter/XMLFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/XMLFormatterTest.java
@@ -103,12 +103,9 @@ public class XMLFormatterTest extends Validator {
     public void testConvertedValidationErrorWithErrorPosition() throws RedPenException {
         // TODO: shorten the procedure before getting formatter result.
         String sampleText = "This is a good day。\n"; // invalid end of sentence symbol
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
-                .build();
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidSymbol"))
+        Configuration conf = Configuration.builder().build();
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .build();
 
         List<cc.redpen.model.Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/model/DocumentCollectionTest.java
+++ b/redpen-core/src/test/java/cc/redpen/model/DocumentCollectionTest.java
@@ -29,7 +29,7 @@ public class DocumentCollectionTest {
     @Test
     public void testCreateDocumentCollection() {
         List<Document> docs = new ArrayList<>();
-        docs.add(new Document.DocumentBuilder()
+        docs.add(Document.builder()
                 .setFileName("Foobar")
                 .addSection(0)
                 .addSectionHeader("baz")
@@ -56,14 +56,14 @@ public class DocumentCollectionTest {
     @Test
     public void testDocumentCollectionWithMultipleDocument() {
         List<Document> docs = new ArrayList<>();
-        docs.add(new Document.DocumentBuilder()
+        docs.add(Document.builder()
                 .setFileName("doc1")
                 .addSection(0)
                 .addSectionHeader("sec1")
                 .addParagraph()
                 .addSentence(new Sentence("sentence00", 1))
                 .addSentence(new Sentence("sentence01", 2)).build());
-        docs.add(new Document.DocumentBuilder()
+        docs.add(Document.builder()
                 .setFileName("doc2")
                 .addSection(0)
                 .addSectionHeader("sec2")

--- a/redpen-core/src/test/java/cc/redpen/model/DocumentTest.java
+++ b/redpen-core/src/test/java/cc/redpen/model/DocumentTest.java
@@ -27,14 +27,14 @@ import static org.junit.Assert.assertEquals;
 public class DocumentTest {
     @Test
     public void testCreateDocument() {
-        Document doc = new Document.DocumentBuilder()
+        Document doc = Document.builder()
                         .setFileName("Foobar").build();
         assertEquals(0, doc.size());
     }
 
     @Test
     public void testCreateDocumentWithList() {
-        Document doc = new Document.DocumentBuilder()
+        Document doc = Document.builder()
                 .setFileName("Foobar")
                 .addSection(0)
                 .addSectionHeader("baz")
@@ -70,7 +70,7 @@ public class DocumentTest {
 
     @Test
     public void testSentenceIsTokenized() {
-        Document doc = new Document.DocumentBuilder()
+        Document doc = Document.builder()
                 .setFileName("foobar")
                 .addSection(0)
                 .addSectionHeader("baz")
@@ -83,7 +83,7 @@ public class DocumentTest {
 
     @Test
     public void testJapaneseSentenceIsTokenized() {
-        Document doc = new Document.DocumentBuilder(new JapaneseTokenizer())
+        Document doc = Document.builder(new JapaneseTokenizer())
                 .setFileName("今日")
                 .addSection(0)
                 .addSectionHeader("天気")
@@ -96,7 +96,7 @@ public class DocumentTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCreateParagraphBeforeSection() {
-        new Document.DocumentBuilder()
+        Document.builder()
                 .setFileName("Foobar")
                 .addParagraph()
                 .addSection(0)
@@ -105,7 +105,7 @@ public class DocumentTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCreateListBlockBeforeSection() {
-        new Document.DocumentBuilder()
+        Document.builder()
                 .setFileName("Foobar")
                 .addListBlock()
                 .addSection(0)
@@ -114,7 +114,7 @@ public class DocumentTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCreateListElementBeforeListBlock() {
-        new Document.DocumentBuilder()
+        Document.builder()
                 .setFileName("Foobar")
                 .addListElement(0, "foo")
                 .addListBlock()

--- a/redpen-core/src/test/java/cc/redpen/parser/SentenceExtractorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/SentenceExtractorTest.java
@@ -41,7 +41,7 @@ public class SentenceExtractorTest {
     @Test
     public void testSimple() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         final String input = "this is a pen.";
         int lastPosition = extractor.extract(input, outputPositions);
@@ -54,7 +54,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentences() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a pen. that is a paper.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -68,7 +68,7 @@ public class SentenceExtractorTest {
     @Test
     public void testTwoSentencesWithDifferentStopCharacters() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "is this a pen? that is a paper.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -81,7 +81,7 @@ public class SentenceExtractorTest {
 
     @Test
     public void testMultipleSentencesWithoutPeriodInTheEnd() {
-        SentenceExtractor extractor = new SentenceExtractor(new Configuration.ConfigurationBuilder().build().getSymbolTable());
+        SentenceExtractor extractor = new SentenceExtractor(Configuration.builder().build().getSymbolTable());
         final String input = "this is a pen. that is a paper";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -94,7 +94,7 @@ public class SentenceExtractorTest {
     @Test
     public void testEndWithDoubleQuotation() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         final String input = "this is a \"pen.\"";
         int lastPosition = extractor.extract(input, outputPositions);
@@ -107,7 +107,7 @@ public class SentenceExtractorTest {
     @Test
     public void testEndWithSingleQuotation() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a \'pen.\'";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -120,7 +120,7 @@ public class SentenceExtractorTest {
     @Test
     public void testEndWithDoubleQuotationEnglishVersion() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a \"pen\".";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -133,7 +133,7 @@ public class SentenceExtractorTest {
     @Test
     public void testEndWithSingleQuotationEnglishVersion() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a \'pen\'.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -146,7 +146,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentencesOneOfThemIsEndWithDoubleQuotation() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a \"pen.\" Another one is not a pen.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -160,7 +160,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentencesWithPartialSplit() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a pen. Another\n" + "one is not a pen.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -174,7 +174,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentencesWithSplitInEndOfSentence() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a pen.\nAnother one is not a pen.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -188,7 +188,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentencesWithPartialSentence() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "this is a pen. Another\n";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -288,7 +288,7 @@ public class SentenceExtractorTest {
     @Test
     public void testSentenceWithWhiteWordPosition() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "He is a Dr. candidate.";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -301,7 +301,7 @@ public class SentenceExtractorTest {
     @Test
     public void testMultipleSentencesWithWhiteWordPosition() {
         SentenceExtractor extractor = new SentenceExtractor
-                (new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                (Configuration.builder().build().getSymbolTable());
         final String input = "Is he a Dr. candidate? Yes, he is.";  // NOTE: white word list contains "Dr."
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -315,7 +315,7 @@ public class SentenceExtractorTest {
     @Test
     public void testVoidLine() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = "";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -327,7 +327,7 @@ public class SentenceExtractorTest {
     @Test
     public void testJustPeriodLine() {
         SentenceExtractor extractor = new SentenceExtractor(
-                new Configuration.ConfigurationBuilder().build().getSymbolTable());
+                Configuration.builder().build().getSymbolTable());
         final String input = ".";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
         int lastPosition = extractor.extract(input, outputPositions);
@@ -370,7 +370,7 @@ public class SentenceExtractorTest {
 
     @Test
     public void testThrowExceptionGivenNull() {
-        SentenceExtractor extractor = new SentenceExtractor(new Configuration.ConfigurationBuilder().build().getSymbolTable());
+        SentenceExtractor extractor = new SentenceExtractor(Configuration.builder().build().getSymbolTable());
         extractor.constructEndSentencePattern(); // not a throw exception
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/parser/asciidoc/AsciiDocTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/asciidoc/AsciiDocTest.java
@@ -32,8 +32,7 @@ public class AsciiDocTest {
      */
     @Test
     public void testModelErasure() {
-
-        Configuration configuration = new Configuration.ConfigurationBuilder().build();
+        Configuration configuration = Configuration.builder().build();
 
         String asciidocText =
                 "[[purpose]]\n" +

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -25,13 +25,15 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class DictionaryLoaderTest extends Validator {
     @Test
@@ -106,18 +108,20 @@ public class DictionaryLoaderTest extends Validator {
         assertTrue(strings.contains("bar"));
     }
 
-    @Test
+    @Test(expected = RedPenException.class)
     public void testEnsureFileIsInsideRedPenHomeOrWorkingDirectory() throws RedPenException, IOException {
         File tempFile = File.createTempFile("redpenTest", "redpenTest");
         String path = tempFile.getAbsolutePath();
         System.setProperty("REDPEN_HOME", path);
         DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(path + File.separator + "test");
         DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(new File("fileInCurrentDirectory.txt").getCanonicalPath());
-        try {
-            File file = new File(path + File.separator + ".." + File.separator + "test");
-            DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(file.getCanonicalPath());
-            fail("expecting RedPenException");
-        } catch (RedPenException expected) {
-        }
+        File file = new File(path + File.separator + ".." + File.separator + "test");
+        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(file.getCanonicalPath());
+    }
+
+    @Test
+    public void testLoadingInexistingResourceReturnsAnEmptyCollection() throws Exception {
+        Set<String> result = new DictionaryLoader<Set<String>>(HashSet::new, null).loadCachedFromResource("hello.xml", "hello");
+        assertTrue(result.isEmpty());
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/util/DictionaryLoaderTest.java
@@ -108,17 +108,6 @@ public class DictionaryLoaderTest extends Validator {
         assertTrue(strings.contains("bar"));
     }
 
-    @Test(expected = RedPenException.class)
-    public void testEnsureFileIsInsideRedPenHomeOrWorkingDirectory() throws RedPenException, IOException {
-        File tempFile = File.createTempFile("redpenTest", "redpenTest");
-        String path = tempFile.getAbsolutePath();
-        System.setProperty("REDPEN_HOME", path);
-        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(path + File.separator + "test");
-        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(new File("fileInCurrentDirectory.txt").getCanonicalPath());
-        File file = new File(path + File.separator + ".." + File.separator + "test");
-        DictionaryLoader.ensureFileIsInsideRedPenHomeOrWorkingDirectory(file.getCanonicalPath());
-    }
-
     @Test
     public void testLoadingInexistingResourceReturnsAnEmptyCollection() throws Exception {
         Set<String> result = new DictionaryLoader<Set<String>>(HashSet::new, null).loadCachedFromResource("hello.xml", "hello");

--- a/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
@@ -21,7 +21,7 @@ public abstract class BaseValidatorTest {
   }
 
   protected Document prepareSimpleDocument(String sentrence) {
-    return new Document.DocumentBuilder(config.getTokenizer())
+    return Document.builder(config.getTokenizer())
       .addSection(1)
       .addParagraph()
       .addSentence(new Sentence(sentrence, 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
@@ -15,7 +15,7 @@ public abstract class BaseValidatorTest {
   }
 
   protected Configuration getConfiguration(String language) {
-    return new Configuration.ConfigurationBuilder()
+    return Configuration.builder()
       .addValidatorConfig(new ValidatorConfiguration(validatorName))
       .setLanguage(language).build();
   }

--- a/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
@@ -28,25 +28,34 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JavaScriptValidatorTest extends JavaScriptValidator {
+    @Test
+    public void doNotCrashIfJsDirectoryDoesNotExist() throws Exception {
+        JavaScriptValidator validator = new JavaScriptValidator();
+        validator.preInit(new ValidatorConfiguration("JavaScript"), Configuration.builder().build());
+        validator.init();
+        assertTrue(validator.scripts.isEmpty());
+    }
+
     @Test
     public void testLoadFile() throws Exception {
         File file = File.createTempFile("test", "txt");
         String content = "hello\nred\npen.";
-        Files.write(Paths.get(file.getAbsolutePath()), content.getBytes(Charset.forName("UTF-8")));
+        Files.write(Paths.get(file.getAbsolutePath()), content.getBytes(UTF_8));
         String loadCached = JavaScriptValidator.loadCached(file);
         assertEquals(content, loadCached);
 
         String content2 = "hello\nred\npen.\nmodified\n";
-        Files.write(Paths.get(file.getAbsolutePath()), content2.getBytes(Charset.forName("UTF-8")));
+        Files.write(Paths.get(file.getAbsolutePath()), content2.getBytes(UTF_8));
         // ensure the modified date differs
         file.setLastModified(System.currentTimeMillis() + 2000);
 
@@ -60,11 +69,11 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
         // delete the temporary file, make a directory, and store JavaScript validator in it
         javaScriptValidatorsDir.delete();
         javaScriptValidatorsDir.mkdirs();
-        System.setProperty("REDPEN_HOME",javaScriptValidatorsDir.getAbsolutePath());
+        System.setProperty("REDPEN_HOME", javaScriptValidatorsDir.getAbsolutePath());
         File validatorJS = new File(javaScriptValidatorsDir.getAbsolutePath() + File.separator + "MyValidator.js");
         String content2 = "function validateSentence(sentence) {\n" +
                 "addLocalizedError(sentence, 'validation error in JavaScript Validator');}";
-        Files.write(Paths.get(validatorJS.getAbsolutePath()), content2.getBytes(Charset.forName("UTF-8")));
+        Files.write(Paths.get(validatorJS.getAbsolutePath()), content2.getBytes(UTF_8));
         validatorJS.deleteOnExit();
 
         Configuration config = Configuration.builder()

--- a/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
@@ -33,8 +33,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -69,7 +67,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
         Files.write(Paths.get(validatorJS.getAbsolutePath()), content2.getBytes(Charset.forName("UTF-8")));
         validatorJS.deleteOnExit();
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("JavaScript").addAttribute("script-path", javaScriptValidatorsDir.getAbsolutePath()))
                 .build();
 

--- a/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/JavaScriptValidatorTest.java
@@ -71,7 +71,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
                 .addValidatorConfig(new ValidatorConfiguration("JavaScript").addAttribute("script-path", javaScriptValidatorsDir.getAbsolutePath()))
                 .build();
 
-        Document document = new Document.DocumentBuilder()
+        Document document = Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("the good item is a good example.", 1))
@@ -110,7 +110,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
                         "_JavaScriptValidatorTest.calledFunctions.add('validateSection');" +
                         // add ValidationError
                         "addLocalizedError(section.getHeaderContent(0), 'section');}"));
-        Document document = new Document.DocumentBuilder()
+        Document document = Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("the good item is a good example.", 1))
@@ -147,7 +147,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
                         "function validateSentence(sentence) {" +
                         // add ValidationError
                         "addLocalizedError(sentence, '[placeholder]');}"));
-        Document document = new Document.DocumentBuilder()
+        Document document = Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("the good item is a good example.", 1))
@@ -173,7 +173,7 @@ public class JavaScriptValidatorTest extends JavaScriptValidator {
                                          + "addLocalizedError(sentence, 'runtime environment is confined');"
                                          + "}"
                                          + "}"));
-        Document document = new Document.DocumentBuilder()
+        Document document = Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("the good item is a good example.", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
@@ -23,8 +23,6 @@ import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Sentence;
 import org.junit.Test;
 
-import java.util.List;
-
 import static junit.framework.Assert.fail;
 
 class NotImplementInterfaceValidator {}
@@ -38,8 +36,7 @@ class NoConstructorWithConfigsValidator extends Validator {
 public class ValidatorFactoryTest {
     @Test
     public void testCreateValidator() {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
                 .build();
         try {
@@ -52,8 +49,7 @@ public class ValidatorFactoryTest {
 
     @Test(expected = RedPenException.class)
     public void testThrowExceptionWhenCreateNonExistValidator() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Foobar"))
                 .build();
         ValidatorFactory.getInstance(
@@ -62,8 +58,7 @@ public class ValidatorFactoryTest {
 
     @Test(expected = RuntimeException.class)
     public void testThrowExceptionWhenCreateValidatorNotImplementsInterface() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("NotImplementInterface"))
                 .build();
         ValidatorFactory.getInstance(
@@ -72,8 +67,7 @@ public class ValidatorFactoryTest {
 
     @Test(expected = RuntimeException.class)
     public void testThrowExceptionWhenCreateValidatorWithoutConstructorWithConfigs() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("NoConstructorWithConfigs"))
                 .build();
         ValidatorFactory.getInstance(

--- a/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
@@ -41,7 +41,7 @@ public class ValidatorFactoryTest {
                 .build();
         try {
             ValidatorFactory.getInstance(
-                    conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+                    conf.getValidatorConfigs().get(0), conf);
         } catch (RedPenException e) {
             fail();
         }
@@ -53,7 +53,7 @@ public class ValidatorFactoryTest {
                 .addValidatorConfig(new ValidatorConfiguration("Foobar"))
                 .build();
         ValidatorFactory.getInstance(
-                conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+                conf.getValidatorConfigs().get(0), conf);
     }
 
     @Test(expected = RuntimeException.class)
@@ -62,7 +62,7 @@ public class ValidatorFactoryTest {
                 .addValidatorConfig(new ValidatorConfiguration("NotImplementInterface"))
                 .build();
         ValidatorFactory.getInstance(
-                conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+                conf.getValidatorConfigs().get(0), conf);
     }
 
     @Test(expected = RuntimeException.class)
@@ -71,7 +71,7 @@ public class ValidatorFactoryTest {
                 .addValidatorConfig(new ValidatorConfiguration("NoConstructorWithConfigs"))
                 .build();
         ValidatorFactory.getInstance(
-                conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+                conf.getValidatorConfigs().get(0), conf);
     }
 
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/section/DuplicatedSectionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/DuplicatedSectionValidatorTest.java
@@ -41,7 +41,7 @@ public class DuplicatedSectionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addSectionHeader("this is header")
                         .addParagraph()
@@ -57,7 +57,6 @@ public class DuplicatedSectionValidatorTest {
         Assert.assertEquals(2, errors.get(documents.get(0)).size());
     }
 
-
     @Test
     public void testDetectNonDuplicatedSection() throws RedPenException {
         Configuration config = Configuration.builder()
@@ -66,7 +65,7 @@ public class DuplicatedSectionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addSectionHeader("foobar")
                         .addParagraph()
@@ -90,7 +89,7 @@ public class DuplicatedSectionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addSectionHeader("this is header.")
                         .addParagraph()
@@ -115,7 +114,7 @@ public class DuplicatedSectionValidatorTest {
         List<Document> documents = new ArrayList<>();
         // create two section which contains only one same word, "baz"
         documents.add(
-        new Document.DocumentBuilder()
+        Document.builder()
                 .addSection(1)
                 .addSectionHeader("foobar")
                 .addParagraph()

--- a/redpen-core/src/test/java/cc/redpen/validator/section/DuplicatedSectionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/DuplicatedSectionValidatorTest.java
@@ -35,9 +35,9 @@ public class DuplicatedSectionValidatorTest {
 
     @Test
     public void testDetectDuplicatedSection() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("DuplicatedSection"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -60,9 +60,9 @@ public class DuplicatedSectionValidatorTest {
 
     @Test
     public void testDetectNonDuplicatedSection() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("DuplicatedSection"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -84,9 +84,9 @@ public class DuplicatedSectionValidatorTest {
 
     @Test
     public void testDetectDuplicatedSectionWithSameHeader() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("DuplicatedSection"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -108,9 +108,9 @@ public class DuplicatedSectionValidatorTest {
 
     @Test
     public void testDetectNonDuplicatedSectionWithLowThreshold() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("DuplicatedSection").addAttribute("threshold", "0.0"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         // create two section which contains only one same word, "baz"

--- a/redpen-core/src/test/java/cc/redpen/validator/section/FrequentSentenceStartValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/FrequentSentenceStartValidatorTest.java
@@ -37,7 +37,7 @@ public class FrequentSentenceStartValidatorTest {
         FrequentSentenceStartValidator validator = (FrequentSentenceStartValidator) ValidatorFactory.getInstance("FrequentSentenceStart");
 
         Document document =
-                new Document.DocumentBuilder(new WhiteSpaceTokenizer())
+                Document.builder(new WhiteSpaceTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("When it comes to the Subject Of Cake (the sweet and delicious baked delicacy), one should" +

--- a/redpen-core/src/test/java/cc/redpen/validator/section/ParagraphNumberValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/ParagraphNumberValidatorTest.java
@@ -60,7 +60,7 @@ public class ParagraphNumberValidatorTest {
         Section section = new Section(0);
         section.appendParagraph(new Paragraph());
 
-        Document document = new Document.DocumentBuilder().appendSection(section).build();
+        Document document = Document.builder().appendSection(section).build();
 
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);

--- a/redpen-core/src/test/java/cc/redpen/validator/section/UnexpandedAcronymValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/UnexpandedAcronymValidatorTest.java
@@ -37,7 +37,7 @@ public class UnexpandedAcronymValidatorTest {
         UnexpandedAcronymValidator validator = (UnexpandedAcronymValidator) ValidatorFactory.getInstance("UnexpandedAcronym");
 
         Document document =
-                new Document.DocumentBuilder(new WhiteSpaceTokenizer())
+                Document.builder(new WhiteSpaceTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("When it comes to the Subject Of Cake (the sweet and delicious baked delicacy), one should" +

--- a/redpen-core/src/test/java/cc/redpen/validator/section/WordFrequencyValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/WordFrequencyValidatorTest.java
@@ -51,7 +51,7 @@ public class WordFrequencyValidatorTest {
                 "By 1285, following a period of social and environmental instability driven by a series of severe and prolonged droughts, they abandoned the area and moved south to locations in Arizona and New Mexico, including Rio Chama, Pajarito Plateau, and Santa Fe."
         };
 
-        Document.DocumentBuilder builder = new Document.DocumentBuilder(new WhiteSpaceTokenizer()).addSection(1).addParagraph();
+        Document.DocumentBuilder builder = Document.builder(new WhiteSpaceTokenizer()).addSection(1).addParagraph();
         int sentenceNumber = 1;
         for (String line : text) {
             builder.addSentence(new Sentence(line, sentenceNumber++));

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/ContractionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/ContractionValidatorTest.java
@@ -34,9 +34,9 @@ import java.util.Map;
 public class ContractionValidatorTest {
     @Test
     public void testContraction() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Contraction"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -55,9 +55,9 @@ public class ContractionValidatorTest {
 
     @Test
     public void testNoContraction() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Contraction"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -76,9 +76,9 @@ public class ContractionValidatorTest {
 
     @Test
     public void testUpperCaseContraction() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Contraction"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -100,9 +100,9 @@ public class ContractionValidatorTest {
      */
     @Test
     public void testManyContractions() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Contraction"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/ContractionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/ContractionValidatorTest.java
@@ -40,7 +40,7 @@ public class ContractionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("he is a super man.", 1))
@@ -61,7 +61,7 @@ public class ContractionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("he is a super man.", 1))
@@ -82,7 +82,7 @@ public class ContractionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("He is a super man.", 1))
@@ -106,7 +106,7 @@ public class ContractionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("he's a super man.", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubleNegativeValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubleNegativeValidatorTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.Map;
 
 import static junit.framework.Assert.assertEquals;
@@ -37,10 +36,8 @@ public class DoubleNegativeValidatorTest {
     @Test
     public void testDetectDoubleNegative() throws Exception {
         String sampleText = "そういう話なら、理解できないこともない。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("DoubleNegative"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;
@@ -62,10 +59,8 @@ public class DoubleNegativeValidatorTest {
     public void testNotDetectSingleNegative() throws Exception {
         String sampleText =
                 "そういう話は理解できない。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("DoubleNegative"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -84,10 +79,8 @@ public class DoubleNegativeValidatorTest {
     public void testNotDetectPositiveType() throws Exception {
         String sampleText =
                 "そういう話は理解できる。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("DoubleNegative"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -105,10 +98,8 @@ public class DoubleNegativeValidatorTest {
     public void testDetectFuzzyDoubleNegative() throws Exception {
         String sampleText =
                 "そういう話なら、ないことないでしょう。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("DoubleNegative"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -127,10 +118,10 @@ public class DoubleNegativeValidatorTest {
     @Test
     public void testDetectEnDoubleNegative() throws Exception {
         String sampleText = "We believe it, unless it is not true";
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(
                         new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("en")
+
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;
@@ -152,10 +143,8 @@ public class DoubleNegativeValidatorTest {
     @Test
     public void testDetectEnDoubleNegativeWithDistance() throws Exception {
         String sampleText = "unless that is not true, I will go there.";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("DoubleNegative"))
-                .setLanguage("en")
+        Configuration config = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("DoubleNegative"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -42,9 +42,9 @@ public class DoubledJoshiValidatorTest {
                 .addSentence(new Sentence("私は彼は好き。", 1))
                 .build());
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi"))
-                .setLanguage("ja").build();
+                .build();
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
@@ -60,9 +60,9 @@ public class DoubledJoshiValidatorTest {
                 .addSentence(new Sentence("私は彼が好き。", 1))
                 .build());
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi"))
-                .setLanguage("ja").build();
+                .build();
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
@@ -78,9 +78,9 @@ public class DoubledJoshiValidatorTest {
                 .addSentence(new Sentence("私は彼は好き。", 1))
                 .build());
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addAttribute("list", "は"))
-                .setLanguage("ja").build();
+                .build();
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -36,7 +36,7 @@ public class DoubledJoshiValidatorTest {
     @Test
     public void testDetectDoubledJoshi() throws Exception {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder(new JapaneseTokenizer())
+        documents.add(Document.builder(new JapaneseTokenizer())
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("私は彼は好き。", 1))
@@ -54,7 +54,7 @@ public class DoubledJoshiValidatorTest {
     @Test
     public void testNotDetectSingleJoshi() throws Exception {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder(new JapaneseTokenizer())
+        documents.add(Document.builder(new JapaneseTokenizer())
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("私は彼が好き。", 1))
@@ -72,7 +72,7 @@ public class DoubledJoshiValidatorTest {
     @Test
     public void testLoadSkipList() throws Exception {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder(new JapaneseTokenizer())
+        documents.add(Document.builder(new JapaneseTokenizer())
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("私は彼は好き。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledWordValidatorTest.java
@@ -69,10 +69,10 @@ public class DoubledWordValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testDoubledUserDefinedSkipWord() throws RedPenException {
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration(validatorName)
                         .addAttribute("list", "redpen,tool"))
-                .setLanguage("en").build();
+                .build();
 
         Document document = prepareSimpleDocument("RedPen is RedPen right?");
 
@@ -83,10 +83,9 @@ public class DoubledWordValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testDoubledUserDefinedSkipWordWithoutNormalization() throws RedPenException {
-        config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(new ValidatorConfiguration(validatorName)
-                        .addAttribute("list", "RedPen,Tool"))
-                .setLanguage("en").build();
+        config = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration(validatorName).addAttribute("list", "RedPen,Tool"))
+                .build();
 
         Document document = prepareSimpleDocument("redPen is redPen right?");
 
@@ -97,9 +96,9 @@ public class DoubledWordValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testDoubledWordInJapaneseSentence() throws RedPenException {
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration(validatorName))
-                .setLanguage("ja").build();
+                .build();
 
         Document document = prepareSimpleDocument("それは真実であり，それが正しい");
 

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/EndOfSentenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/EndOfSentenceValidatorTest.java
@@ -81,7 +81,7 @@ public class EndOfSentenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("彼は言った，“今日は誕生日”。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/EndOfSentenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/EndOfSentenceValidatorTest.java
@@ -76,9 +76,9 @@ public class EndOfSentenceValidatorTest {
 
     @Test
     public void testJapaneseInvalidEndOfSentence() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("EndOfSentence"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())
@@ -95,9 +95,8 @@ public class EndOfSentenceValidatorTest {
     @Test
     public void testErrorPosition() throws RedPenException {
         String sampleText = "He said \"that is right\".";
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("EndOfSentence"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("EndOfSentence"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/HyphenationValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/HyphenationValidatorTest.java
@@ -37,7 +37,7 @@ public class HyphenationValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new WhiteSpaceTokenizer())
+                Document.builder(new WhiteSpaceTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("Hyphenation is very useful to stop a sentence such as bad tempered " +

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
@@ -43,9 +43,9 @@ public class InvalidExpressionValidatorTest {
 
     @Test
     public void testSimpleRun() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression").addAttribute("list", "may"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -55,9 +55,9 @@ public class InvalidExpressionValidatorTest {
 
     @Test
     public void testVoid() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression").addAttribute("list", "may"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -67,9 +67,9 @@ public class InvalidExpressionValidatorTest {
 
     @Test
     public void testLoadDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()
@@ -85,9 +85,9 @@ public class InvalidExpressionValidatorTest {
 
     @Test
     public void testLoadJapaneseDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())
@@ -104,9 +104,9 @@ public class InvalidExpressionValidatorTest {
 
     @Test
     public void testLoadJapaneseInvalidList() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression").addAttribute("list", "うふぉ,ガチ"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())
@@ -123,9 +123,8 @@ public class InvalidExpressionValidatorTest {
     @Test
     public void testErrorPosition() throws RedPenException {
         String sampleText = "Hello You know."; // invalid expression "You know"
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("InvalidExpression"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
@@ -72,7 +72,7 @@ public class InvalidExpressionValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("You know. He is a super man.", 1))
@@ -90,7 +90,7 @@ public class InvalidExpressionValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("明日地球が滅亡するってマジですか。", 1))
@@ -109,7 +109,7 @@ public class InvalidExpressionValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("うふぉっ本当ですか？", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidExpressionValidatorTest.java
@@ -46,7 +46,7 @@ public class InvalidExpressionValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression").addAttribute("list", "may"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(new Sentence("The experiments may be true.", 0));
@@ -58,7 +58,7 @@ public class InvalidExpressionValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression").addAttribute("list", "may"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(new Sentence("", 0));

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
@@ -50,9 +50,8 @@ public class InvalidSymbolValidatorTest {
                         .addSentence(new Sentence("わたしはカラオケが大好き！", 1))
                         .build());
 
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
                 .build();
 
@@ -73,9 +72,8 @@ public class InvalidSymbolValidatorTest {
                         .addSentence(new Sentence("I like Karaoke", 1))
                         .build());
 
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
                 .build();
 
@@ -95,9 +93,8 @@ public class InvalidSymbolValidatorTest {
                         .addSentence(new Sentence("わたしは、カラオケが大好き！", 1)) // NOTE: two invalid symbols
                         .build());
 
-        Configuration conf = new Configuration.ConfigurationBuilder()
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
                 .addSymbol(new Symbol(COMMA, ',', "、"))
                 .build();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
@@ -44,7 +44,7 @@ public class InvalidSymbolValidatorTest {
     public void testWithInvalidSymbol() throws RedPenException {
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("わたしはカラオケが大好き！", 1))
@@ -66,7 +66,7 @@ public class InvalidSymbolValidatorTest {
     public void testWithoutInvalidSymbol() throws RedPenException {
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("I like Karaoke", 1))
@@ -87,7 +87,7 @@ public class InvalidSymbolValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("わたしは、カラオケが大好き！", 1)) // NOTE: two invalid symbols

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
@@ -51,7 +51,7 @@ public class InvalidWordValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord").addAttribute("list", "foolish"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
 
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -71,7 +71,7 @@ public class InvalidWordValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord").addAttribute("list", "foolish"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
@@ -42,7 +42,7 @@ public class InvalidWordValidatorTest {
     @Test
     public void testSimpleRun() throws RedPenException {
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("He is a foolish guy.", 1))
@@ -62,7 +62,7 @@ public class InvalidWordValidatorTest {
     @Test
     public void testVoid() throws RedPenException {
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("", 1))
@@ -85,7 +85,7 @@ public class InvalidWordValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("he is a foolish man.", 1))
@@ -105,7 +105,7 @@ public class InvalidWordValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("Domo is a greeting word in Japan.", 1))
@@ -126,7 +126,7 @@ public class InvalidWordValidatorTest {
                 .build(); // NOTE: no dictionary for japanese or other languages whose words are not split by white space.
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("こんにちは、群馬にきました。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
@@ -113,14 +113,14 @@ public class InvalidWordValidatorTest {
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
-        Assert.assertEquals(1, errors.get(documents.get(0)).size());
+        assertEquals(1, errors.get(documents.get(0)).size());
     }
 
     /**
      * Assert not throw a exception even when there is no default dictionary.
      */
-    @Test(expected = RedPenException.class)
-    public void testLoadNotExistDefaultDictionary() throws RedPenException {
+    @Test
+    public void testLoadNotExistingDefaultDictionary() throws RedPenException {
         Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord"))
                 .build(); // NOTE: no dictionary for japanese or other languages whose words are not split by white space.
@@ -134,6 +134,6 @@ public class InvalidWordValidatorTest {
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
-        Assert.assertEquals(0, errors.get(documents.get(0)).size());
+        assertEquals(0, errors.get(documents.get(0)).size());
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidWordValidatorTest.java
@@ -48,9 +48,9 @@ public class InvalidWordValidatorTest {
                         .addSentence(new Sentence("He is a foolish guy.", 1))
                         .build());
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord").addAttribute("list", "foolish"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
 
         List<ValidationError> errors = new ArrayList<>();
@@ -68,9 +68,9 @@ public class InvalidWordValidatorTest {
                         .addSentence(new Sentence("", 1))
                         .build());
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord").addAttribute("list", "foolish"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -80,9 +80,9 @@ public class InvalidWordValidatorTest {
 
     @Test
     public void testLoadDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()
@@ -100,9 +100,9 @@ public class InvalidWordValidatorTest {
 
     @Test
     public void testLoadUserDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord").addAttribute("list", "boom,domo"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()
@@ -121,9 +121,9 @@ public class InvalidWordValidatorTest {
      */
     @Test(expected = RedPenException.class)
     public void testLoadNotExistDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("InvalidWord"))
-                .setLanguage("ja").build(); // NOTE: no dictionary for japanese or other languages whose words are not split by white space.
+                .build(); // NOTE: no dictionary for japanese or other languages whose words are not split by white space.
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseStyleValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseStyleValidatorTest.java
@@ -68,7 +68,7 @@ public class JapaneseStyleValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("今日はいい天気ですね。", 1))
@@ -89,7 +89,7 @@ public class JapaneseStyleValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("今日はいい天気である。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseStyleValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseStyleValidatorTest.java
@@ -41,10 +41,8 @@ public class JapaneseStyleValidatorTest {
                 "今日はいい天気ですね。\n" +
                 "昨日は雨だったのだが、持ち直した。\n" +
                 "明日もいい天気だといいですね。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("JapaneseStyle"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("JapaneseStyle"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -64,9 +62,9 @@ public class JapaneseStyleValidatorTest {
 
     @Test
     public void desuMasuStyle() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("JapaneseStyle"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -85,9 +83,9 @@ public class JapaneseStyleValidatorTest {
 
     @Test
     public void dearuStyle() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("JapaneseStyle"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
@@ -17,21 +17,19 @@
  */
 package cc.redpen.validator.sentence;
 
-import cc.redpen.model.Sentence;
-import cc.redpen.validator.ValidationError;
-import org.junit.Test;
-
 import cc.redpen.RedPen;
 import cc.redpen.RedPenException;
 import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Document;
+import cc.redpen.model.Sentence;
+import cc.redpen.validator.ValidationError;
+import org.junit.Test;
 
 import java.io.File;
-import java.util.Map;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -181,10 +179,9 @@ public class KatakanaEndHyphenValidatorTest {
 
     @Test
     public void testHonorsSkipWordList() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(new ValidatorConfiguration("KatakanaEndHyphen")
-                        .addAttribute("list", "コーヒー"))
-                .setLanguage("ja").build();
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("KatakanaEndHyphen").addAttribute("list", "コーヒー"))
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()
@@ -200,10 +197,10 @@ public class KatakanaEndHyphenValidatorTest {
 
     @Test
     public void testHonorsSkipWordDict() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("KatakanaEndHyphen")
                         .addAttribute("dict", "src/test/resources/cc/redpen/validator/KatakanaEndHyphenValidatorTest-skipworddict.txt")) // XXX
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
@@ -184,7 +184,7 @@ public class KatakanaEndHyphenValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("濃いコーヒーは胃にわるい。", 1))
@@ -203,7 +203,7 @@ public class KatakanaEndHyphenValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("コーヒーと紅茶と、どちらがお好きですか。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidatorTest.java
@@ -69,9 +69,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testLoadDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -88,9 +88,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testDefaultSetting() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -107,10 +107,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testSetMinimumRatio() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck")
-                        .addAttribute("min_ratio", "0.001"))
-                .setLanguage("ja").build();
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck").addAttribute("min_ratio", "0.001"))
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -127,10 +126,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testSetMinimumFrequency() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck")
-                        .addAttribute("min_freq", "0"))
-                .setLanguage("ja").build();
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck").addAttribute("min_freq", "0"))
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -147,9 +145,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testLoadUserDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck").addAttribute("list", "ミニマムサポート,ミニマムサポータ"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(
@@ -166,9 +164,9 @@ public class KatakanaSpellCheckValidatorTest {
 
     @Test
     public void testDisableDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("KatakanaSpellCheck").addAttribute("disable-default", "true"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder()

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidatorTest.java
@@ -75,7 +75,7 @@ public class KatakanaSpellCheckValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのインデクスとこのインデックス", 1))
@@ -94,7 +94,7 @@ public class KatakanaSpellCheckValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのミニマムサポートとこのミニマムサポータ", 1))
@@ -113,7 +113,7 @@ public class KatakanaSpellCheckValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのミニマムサポートとこのミニマムサポータ", 1))
@@ -132,7 +132,7 @@ public class KatakanaSpellCheckValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのミニマムサポートとこのミニマムサポータ", 1))
@@ -151,7 +151,7 @@ public class KatakanaSpellCheckValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのミニマムサポートとこのミニマムサポータ。", 1))
@@ -169,7 +169,7 @@ public class KatakanaSpellCheckValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder()
+                Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("あのインデクスとこのインデックス", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/OkuriganaValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/OkuriganaValidatorTest.java
@@ -36,10 +36,8 @@ public class OkuriganaValidatorTest {
     @Test
     public void testInvalidOkurigana() throws Exception {
         String sampleText = "このタスクに長い年月を費してきた。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("Okurigana"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("Okurigana"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;
@@ -60,10 +58,8 @@ public class OkuriganaValidatorTest {
     @Test
     public void testNoInvalidOkurigana() throws Exception {
         String sampleText = "このタスクに長い年月を費やしてきた。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("Okurigana"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("Okurigana"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;
@@ -83,10 +79,8 @@ public class OkuriganaValidatorTest {
     @Test
     public void testInvalidOkuriganaWithRule() throws Exception {
         String sampleText = "彼に合せた。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("Okurigana"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("Okurigana"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;
@@ -109,10 +103,8 @@ public class OkuriganaValidatorTest {
     @Test
     public void testValidOkuriganaWithRule() throws Exception {
         String sampleText = "それとは競合している。";
-        Configuration config = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("Okurigana"))
-                .setLanguage("ja")
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("Okurigana"))
                 .build();
 
         DocumentParser parser = DocumentParser.MARKDOWN;

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/ParenthesizedSentenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/ParenthesizedSentenceValidatorTest.java
@@ -35,7 +35,7 @@ public class ParenthesizedSentenceValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new WhiteSpaceTokenizer())
+                Document.builder(new WhiteSpaceTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("When it comes to the subject of cake (the sweet and delicious baked delicacy), one should" +

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
@@ -172,7 +172,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", false))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("I'm a jedi knight.", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -186,7 +186,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", false))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("I said \"that is true\".", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -200,7 +200,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("I said that is true.", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -214,7 +214,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -261,7 +261,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("I said\"that is true\".", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -286,7 +286,7 @@ public class QuotationValidatorTest {
         Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
         Sentence str = new Sentence("I said \"that is true\"is true.", 0);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -301,7 +301,7 @@ public class QuotationValidatorTest {
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .addSymbol(new Symbol(SymbolType.FULL_STOP, '。'))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf);
 
 //        QuotationValidator validator =
 //                new QuotationValidator(true, '。');

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
@@ -169,8 +169,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testAsciiExceptionCase() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", false))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -184,8 +183,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testAsciiDoubleQuotationMakrk() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", false))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -199,8 +197,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testNoQuotationMakrk() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -214,8 +211,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testNoInput() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -262,8 +258,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testLeftAsciiDoubleQuotationsWihtoutSpace() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -288,8 +283,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testRightAsciiDoubleQuotationsWihtoutSpace() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
@@ -303,8 +297,7 @@ public class QuotationValidatorTest {
 
     @Test
     public void testDoubleQuotationsWithNonAsciiPeriod() throws RedPenException {
-        Configuration conf = new Configuration.ConfigurationBuilder()
-                .setLanguage("en")
+        Configuration conf = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
                 .addSymbol(new Symbol(SymbolType.FULL_STOP, '。'))
                 .build();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSpenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSpenceValidatorTest.java
@@ -40,7 +40,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("this is a test.", 1)) // ok since the sentence begins with the beginning of the line 1
@@ -59,7 +59,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("this is a test", 1))
@@ -78,7 +78,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("This is a test", 1))
@@ -96,7 +96,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("", 0))
@@ -114,7 +114,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("this is a test.", 1))
@@ -133,7 +133,7 @@ public class SpaceBeginningOfSpenceValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-                documents.add(new Document.DocumentBuilder()
+                documents.add(Document.builder()
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSpenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSpenceValidatorTest.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.assertEquals;
 public class SpaceBeginningOfSpenceValidatorTest {
     @Test
     public void testProcessSentenceWithoutEndSpace() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()
@@ -54,9 +54,9 @@ public class SpaceBeginningOfSpenceValidatorTest {
 
     @Test
     public void testProcessFirstSpace() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()
@@ -73,9 +73,9 @@ public class SpaceBeginningOfSpenceValidatorTest {
 
     @Test
     public void testProcessHeadSentenceInAParagraph() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()
@@ -91,9 +91,9 @@ public class SpaceBeginningOfSpenceValidatorTest {
 
     @Test
     public void testProcessZeroLengthSentence() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()
@@ -109,9 +109,9 @@ public class SpaceBeginningOfSpenceValidatorTest {
 
     @Test
     public void testProcessNewLineSentenceWithoutEndSpace() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()
@@ -128,9 +128,9 @@ public class SpaceBeginningOfSpenceValidatorTest {
 
     @Test
     public void testProcessVoidSentence() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBeginningOfSentence"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
                 documents.add(new Document.DocumentBuilder()

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
@@ -85,9 +85,9 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
 
     @Test
     public void testWithParenthesis() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())
@@ -103,9 +103,9 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
 
     @Test
     public void testWithComma() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
-                .setLanguage("ja").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
                 new Document.DocumentBuilder(new JapaneseTokenizer())
@@ -122,9 +122,8 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
     @Test
     public void testErrorBeforePosition() throws RedPenException {
         String sampleText = "きょうはCoke を飲みたい。";
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -143,9 +142,8 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
     @Test
     public void testErrorAfterPosition() throws RedPenException {
         String sampleText = "きょうは Cokeを飲みたい。";
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
@@ -90,7 +90,7 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("きょうは（Coke）を飲みたい。", 1))
@@ -108,7 +108,7 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();documents.add(
-                new Document.DocumentBuilder(new JapaneseTokenizer())
+                Document.builder(new JapaneseTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("きょうは、Coke を飲みたい。", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
@@ -42,9 +42,9 @@ public class SpellingValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testValidate() throws Exception {
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
           .addValidatorConfig(new ValidatorConfiguration(validatorName).addAttribute("list", "this,a,pen"))
-          .setLanguage("en").build();
+          .build();
 
         Document document = prepareSimpleDocument("this iz a pen");
 
@@ -86,9 +86,9 @@ public class SpellingValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testUserSkipList() throws RedPenException {
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration(validatorName).addAttribute("list", "abeshi,baz"))
-                .setLanguage("en").build();
+                .build();
 
         Document document = prepareSimpleDocument("Abeshi is a word used in a comic.");
 

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
@@ -48,7 +48,7 @@ public class SpellingValidatorTest extends BaseValidatorTest {
 
         Document document = prepareSimpleDocument("this iz a pen");
 
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
 
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
@@ -40,7 +40,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testDetectStartWithSmallCharacter() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("this is it.", 1))
@@ -58,7 +58,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testDetectStartWithCapitalCharacter() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("This is it.", 1))
@@ -76,7 +76,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testStartWithElementOfWhiteList() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("iPhone is a mobile computer.", 1))
@@ -94,7 +94,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testStartWithWhiteListItemInJapaneseSentence() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder(new JapaneseTokenizer())
+        documents.add(Document.builder(new JapaneseTokenizer())
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("iPhone はカッコイイ．", 1))
@@ -112,7 +112,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testStartWithWhiteSpaceAndThenItemOfWhiteList() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence(" iPhone is a mobile computer.", 1))
@@ -130,7 +130,7 @@ public class StartWithCapitalLetterValidatorTest {
     @Test
     public void testVoid() throws RedPenException {
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("", 1))
@@ -152,7 +152,7 @@ public class StartWithCapitalLetterValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("mixi is a Japanese company.", 1))
@@ -171,7 +171,7 @@ public class StartWithCapitalLetterValidatorTest {
                 .build();
 
         List<Document> documents = new ArrayList<>();
-        documents.add(new Document.DocumentBuilder()
+        documents.add(Document.builder()
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("This is true.", 1))

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
@@ -45,9 +45,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence("this is it.", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -63,9 +63,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence("This is it.", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -81,9 +81,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence("iPhone is a mobile computer.", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -99,9 +99,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence("iPhone はカッコイイ．", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -117,9 +117,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence(" iPhone is a mobile computer.", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -135,9 +135,9 @@ public class StartWithCapitalLetterValidatorTest {
                 .addParagraph()
                 .addSentence(new Sentence("", 1))
                 .build());
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
-                .setLanguage("en").build();
+                .build();
         Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
@@ -147,9 +147,9 @@ public class StartWithCapitalLetterValidatorTest {
 
     @Test
     public void testLoadDefaultDictionary() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(new Document.DocumentBuilder()
@@ -166,9 +166,9 @@ public class StartWithCapitalLetterValidatorTest {
 
     @Test
     public void testDetectStartWithSmallCharacterInSecondSentence() throws RedPenException {
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
-                .setLanguage("en").build();
+                .build();
 
         List<Document> documents = new ArrayList<>();
         documents.add(new Document.DocumentBuilder()

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/StartWithCapitalLetterValidatorTest.java
@@ -48,7 +48,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));
@@ -66,7 +66,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));
@@ -84,7 +84,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));
@@ -102,7 +102,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));
@@ -120,7 +120,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));
@@ -138,7 +138,7 @@ public class StartWithCapitalLetterValidatorTest {
         Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("StartWithCapitalLetter").addAttribute("list", "iPhone"))
                 .build();
-        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config.getSymbolTable());
+        Validator validator = ValidatorFactory.getInstance(config.getValidatorConfigs().get(0), config);
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(documents.get(0).getLastSection().getParagraph(0).getSentence(0));

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
@@ -50,9 +50,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     public void testNotNeedSpace() throws RedPenException {
         Document document = prepareSimpleDocument("I like apple/orange");
 
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(SLASH, '/'))
                 .build();
 
@@ -65,9 +64,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     public void testNeedAfterSpace() throws RedPenException {
         Document document = prepareSimpleDocument("I like her:yes it is");
 
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(COLON, ':', "", false, true))
                 .build();
 
@@ -82,9 +80,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     public void testNeedBeforeSpace() throws RedPenException {
         Document document = prepareSimpleDocument("I like her(Nancy) very much.");
 
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
                 .build();
 
@@ -99,9 +96,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     public void testNeedSpaceInMultiplePosition() throws RedPenException {
         Document document = prepareSimpleDocument("I like her(Nancy)very much.");
 
-        config = new Configuration.ConfigurationBuilder()
+        config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
                 .addSymbol(new Symbol(RIGHT_PARENTHESIS, ')', "", false, true))
                 .build();
@@ -117,9 +113,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     public void testReturnOnlyOneForHitBothBeforeAndAfter() throws RedPenException {
         Document document = prepareSimpleDocument("I like 1*10.");
 
-        Configuration config = new Configuration.ConfigurationBuilder()
+        Configuration config = Configuration.builder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
-                .setLanguage("en")
                 .addSymbol(new Symbol(ASTERISK, '*', "", true, true))
                 .build();
 
@@ -132,9 +127,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     @Test
     public void testErrorBeforePosition() throws RedPenException {
         String sampleText = "I like her(Nancy) very much.";
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SymbolWithSpace"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();
@@ -154,9 +148,8 @@ public class SymbolWithSpaceValidatorTest extends BaseValidatorTest {
     @Test
     public void testErrorAfterPosition() throws RedPenException {
         String sampleText = "I like her (Nancy)very much.";
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(
-                        new ValidatorConfiguration("SymbolWithSpace"))
+        Configuration configuration = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .build();
         DocumentParser parser = DocumentParser.MARKDOWN;
         List<Document> documents = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/WeakExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/WeakExpressionValidatorTest.java
@@ -37,7 +37,7 @@ public class WeakExpressionValidatorTest {
 
         List<Document> documents = new ArrayList<>();
         documents.add(
-                new Document.DocumentBuilder(new WhiteSpaceTokenizer())
+                Document.builder(new WhiteSpaceTokenizer())
                         .addSection(1)
                         .addParagraph()
                         .addSentence(new Sentence("As a matter of fact, some things are very small.", 1))

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java
@@ -108,8 +108,7 @@ public class RedPenService {
      * @return a configured redpen instance
      */
     public RedPen getRedPen(String lang, Map<String, Map<String, String>> validatorProperties) {
-
-        Configuration.ConfigurationBuilder configBuilder = new Configuration.ConfigurationBuilder();
+        Configuration.ConfigurationBuilder configBuilder = Configuration.builder();
         configBuilder.setLanguage(lang);
 
         // add the validators and their properties


### PR DESCRIPTION
Custom resources will now be looked for from 3 places:

* Working directory
* Relative to the config file (new feature)
* From REDPEN_HOME directory

All Validators now have access to this functionality via Validator.findFile().
All existing validators were updated to use it.

**WARNING:** This pull request depends (contains the same changes) on this one https://github.com/redpen-cc/redpen/pull/550, please merge #550 first.

Review changes starting from this commit: https://github.com/codeborne/redpen/commit/042cfdc9a072ff64513780f17b87c848930fa53f