### PR TITLE
export REDPEN_HOME so that RedPenServer can read with getEnv

### DIFF
--- a/redpen-server/bin/redpen-server
+++ b/redpen-server/bin/redpen-server
@@ -20,7 +20,7 @@ done
 REDPEN_HOME=`dirname "$SCRIPT"`/..
 
 # Make REDPEN_HOME absolute
-REDPEN_HOME=`cd "$REDPEN_HOME"; pwd`
+export REDPEN_HOME=`cd "$REDPEN_HOME"; pwd`
 
 #####################################################
 #


### PR DESCRIPTION
redpen-server script didn't export $REDPEN_HOME, and JavaScriptValidator was trying to read JavaScript validators from bin/js, not $REDPEN_HOME/js.