### PR TITLE
Improve redpen-server security

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/config/ConfigurationLoader.java
@@ -40,7 +40,7 @@ import static cc.redpen.config.Configuration.ConfigurationBuilder;
  */
 public class ConfigurationLoader {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLoader.class);
-    private ConfigurationBuilder configBuilder = new ConfigurationBuilder();
+    private boolean secure;
 
     private static Symbol createSymbol(Element element) throws RedPenException {
         if (!element.hasAttribute("name") || !element.hasAttribute("value")) {
@@ -165,7 +165,8 @@ public class ConfigurationLoader {
     public Configuration load(InputStream stream, File base) throws RedPenException {
         Document doc = toDocument(stream);
 
-        configBuilder = new ConfigurationBuilder().setBaseDir(base);
+        ConfigurationBuilder configBuilder = new ConfigurationBuilder().setBaseDir(base);
+        if (secure) configBuilder.secure();
         Element rootElement = getRootNode(doc, "redpen-conf");
 
         String language = rootElement.getAttribute("lang");
@@ -196,7 +197,7 @@ public class ConfigurationLoader {
             LOG.warn("There is no validators block");
         } else {
             NodeList validatorElementList = validatorConfigElementList.item(0).getChildNodes();
-            extractValidatorConfigurations(validatorElementList);
+            extractValidatorConfigurations(configBuilder, validatorElementList);
         }
 
         // extract symbol configurations
@@ -206,12 +207,12 @@ public class ConfigurationLoader {
         if (!variant.isEmpty()) configBuilder.setVariant(variant);
 
         if (symbolTableConfigElementList != null) {
-            extractSymbolConfig(symbolTableConfigElementList, language);
+            extractSymbolConfig(configBuilder, symbolTableConfigElementList, language);
         }
         return configBuilder.build();
     }
 
-    private void extractValidatorConfigurations(NodeList validatorElementList) {
+    private void extractValidatorConfigurations(ConfigurationBuilder configBuilder, NodeList validatorElementList) {
         ValidatorConfiguration currentConfiguration;
         for (int i = 0; i < validatorElementList.getLength(); i++) {
             Node nNode = validatorElementList.item(i);
@@ -249,7 +250,7 @@ public class ConfigurationLoader {
         }
     }
 
-    private void extractSymbolConfig(NodeList symbolTableConfigElementList, String language) throws RedPenException {
+    private void extractSymbolConfig(ConfigurationBuilder configBuilder, NodeList symbolTableConfigElementList, String language) throws RedPenException {
         configBuilder.setLanguage(language);
 
         NodeList symbolTableElementList =
@@ -297,5 +298,10 @@ public class ConfigurationLoader {
         Element rootElement = (Element) root;
         LOG.info("Succeeded to load configuration file");
         return rootElement;
+    }
+
+    public ConfigurationLoader secure() {
+        secure = true;
+        return this;
     }
 }

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -101,7 +101,7 @@ public class RedPenResource {
         if (config == null) {
             redPen = new RedPenService(context).getRedPen(lang);
         } else {
-            redPen = new RedPen(new ConfigurationLoader().loadFromString(config));
+            redPen = new RedPen(new ConfigurationLoader().secure().loadFromString(config));
         }
         Document parsedDocument = redPen.parse(DocumentParser.of(documentParser), document);
         List<ValidationError> errors = redPen.validate(parsedDocument);

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenResourceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenResourceTest.java
@@ -30,6 +30,9 @@ import javax.ws.rs.core.MediaType;
 import java.io.FileNotFoundException;
 import java.util.Set;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.WILDCARD;
+
 public class RedPenResourceTest extends MockServletInvocationTest {
 
     @Override
@@ -45,7 +48,7 @@ public class RedPenResourceTest extends MockServletInvocationTest {
 
     public void testRun() throws Exception {
         MockHttpServletRequest request =
-                constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
+                constructMockRequest("POST", "/document/validate", WILDCARD);
         request.setContent(("document=Foobar").getBytes());
         MockServletContext context = new MockServletContext();
         context.addInitParameter("redpen.conf.path", "conf/redpen-conf.xml");
@@ -57,8 +60,7 @@ public class RedPenResourceTest extends MockServletInvocationTest {
     }
 
     public void testRunWithErrors() throws Exception {
-        MockHttpServletRequest request =
-                constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
+        MockHttpServletRequest request = constructMockRequest("POST", "/document/validate", WILDCARD);
         request.setContent(("document=foobar.foobar").getBytes()); //NOTE: need space between periods.
         MockServletContext context = new MockServletContext();
         context.addInitParameter("redpen.conf.path", "conf/redpen-conf.xml");
@@ -74,8 +76,7 @@ public class RedPenResourceTest extends MockServletInvocationTest {
     }
 
     public void testRunWithoutContent() throws Exception {
-        MockHttpServletRequest request =
-                constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
+        MockHttpServletRequest request = constructMockRequest("POST", "/document/validate", WILDCARD);
         request.setContent(("").getBytes()); //NOTE: need space between periods.
         MockServletContext context = new MockServletContext();
         context.addInitParameter("redpen.conf.path", "conf/redpen-conf.xml");
@@ -84,8 +85,7 @@ public class RedPenResourceTest extends MockServletInvocationTest {
     }
 
     public void testRunWithOnlyFormName() throws Exception {
-        MockHttpServletRequest request =
-                constructMockRequest("POST", "/document/validate", MediaType.WILDCARD);
+        MockHttpServletRequest request = constructMockRequest("POST", "/document/validate", WILDCARD);
         request.setContent(("document=").getBytes()); //NOTE: need space between periods.
         MockServletContext context = new MockServletContext();
         context.addInitParameter("redpen.conf.path", "conf/redpen-conf.xml");
@@ -95,19 +95,29 @@ public class RedPenResourceTest extends MockServletInvocationTest {
     }
 
     public void testJSValidatorRuns() throws Exception {
-        MockHttpServletRequest request =
-            constructMockRequest("POST", "/document/validate/json", MediaType.WILDCARD, MediaType.APPLICATION_JSON);
-        request.setContent(String.format("{\"document\":\"Test, this is a test.\",\"format\":\"json2\",\"documentParser\":\"PLAIN\",\"config\":{\"lang\":\"en\",\"validators\":{\"JavaScript\":{\"properties\":{\"script-path\":\"%s\"}}}}}", "./src/test/resources/js").getBytes());
-        MockServletContext context = new MockServletContext();
+        System.setProperty("REDPEN_HOME", "src/test");
+        MockHttpServletRequest request = constructMockRequest("POST", "/document/validate/json", WILDCARD, APPLICATION_JSON);
+        request.setContent(String.format("{\"document\":\"Test, this is a test.\",\"format\":\"json2\",\"documentParser\":\"PLAIN\",\"config\":{\"lang\":\"en\",\"validators\":{\"JavaScript\":{\"properties\":{\"script-path\":\"%s\"}}}}}", "resources/js").getBytes());
         MockHttpServletResponse response = invoke(request);
 
         assertEquals("HTTP status", HttpStatus.OK.getCode(), response.getStatus());
-        final JSONArray errors = new JSONObject(response.getContentAsString()).getJSONArray("errors");
+        JSONArray errors = new JSONObject(response.getContentAsString()).getJSONArray("errors");
         assertTrue(errors.length() > 0);
         for (int i=0; i<errors.length(); ++i) {
-            final JSONObject o = errors.getJSONObject(i).getJSONArray("errors").getJSONObject(0);
+            JSONObject o = errors.getJSONObject(i).getJSONArray("errors").getJSONObject(0);
             assertEquals("[pass.js] called", o.getString("message"));
         }
+    }
+
+    public void testJSValidatorDoesntRunFromNonHomeDir() throws Exception {
+        System.setProperty("REDPEN_HOME", ".");
+        MockHttpServletRequest request = constructMockRequest("POST", "/document/validate/json", WILDCARD, APPLICATION_JSON);
+        request.setContent(String.format("{\"document\":\"Test, this is a test.\",\"format\":\"json2\",\"documentParser\":\"PLAIN\",\"config\":{\"lang\":\"en\",\"validators\":{\"JavaScript\":{\"properties\":{\"script-path\":\"%s\"}}}}}", "resources/js").getBytes());
+        MockHttpServletResponse response = invoke(request);
+
+        assertEquals("HTTP status", HttpStatus.OK.getCode(), response.getStatus());
+        JSONArray errors = new JSONObject(response.getContentAsString()).getJSONArray("errors");
+        assertEquals(0, errors.length());
     }
 
     public void testDetectLanguage() throws Exception {

--- a/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
+++ b/redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java
@@ -1,13 +1,22 @@
 package cc.redpen.server.api;
 
 import cc.redpen.RedPen;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockServletContext;
 
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RedPenServiceTest {
+  @Before
+  public void setUp() {
+    RedPenService.langRedPenMap.clear();
+  }
+
   @Test
   public void twoConfigurationsByDefault() throws Exception {
     RedPenService service = new RedPenService(null);
@@ -24,5 +33,22 @@ public class RedPenServiceTest {
 
     assertEquals("ja", redPens.get("ja.hankaku").getConfiguration().getLang());
     assertEquals("hankaku", redPens.get("ja.hankaku").getConfiguration().getVariant());
+
+    assertTrue(redPens.values().stream().allMatch(r -> r.getConfiguration().isSecure()));
+  }
+
+  @Test
+  public void canSpecifyDifferentDefaultConfiguration() throws Exception {
+    MockServletContext context = new MockServletContext();
+    context.addInitParameter("redpen.conf.path", "/conf/redpen-conf-ja.xml");
+    RedPen defaultRedPen = new RedPenService(context).getRedPen("default");
+    assertEquals("ja", defaultRedPen.getConfiguration().getKey());
+    assertTrue(defaultRedPen.getConfiguration().isSecure());
+  }
+
+  @Test
+  public void redPensWithCustomPropertiesAreAlsoSecure() throws Exception {
+    RedPen en = new RedPenService(null).getRedPen("en", emptyMap());
+    assertTrue(en.getConfiguration().isSecure());
   }
 }


### PR DESCRIPTION
Introduce secure mode to Configuration.findFile(), which is needed in redpen-server to disallow loading of arbitrary files with user-provided config.

User can specify file paths using "dict" attribute for many validators, forcing the server to read these files from its own filesystem, potentially giving the possibility to the user to derive whether some content is there or not.