### PR TITLE
Be able to support all available validators in external editors/wordpress

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -21,6 +21,7 @@ import cc.redpen.RedPenException;
 import cc.redpen.tokenizer.JapaneseTokenizer;
 import cc.redpen.tokenizer.RedPenTokenizer;
 import cc.redpen.tokenizer.WhiteSpaceTokenizer;
+import cc.redpen.validator.ValidatorFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -256,6 +257,12 @@ public class Configuration implements Serializable, Cloneable {
         public ConfigurationBuilder addValidatorConfig(ValidatorConfiguration config) {
             checkBuilt();
             validatorConfigs.add(config);
+            return this;
+        }
+
+        public ConfigurationBuilder addAvailableValidatorConfigs() {
+            checkBuilt();
+            validatorConfigs.addAll(ValidatorFactory.getConfigurations(lang));
             return this;
         }
 

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -46,6 +47,13 @@ public class Configuration implements Serializable, Cloneable {
     private final File home = new File(Optional.ofNullable(System.getProperty("REDPEN_HOME", System.getenv("REDPEN_HOME"))).orElse(""));
     private final File base;
     private final boolean secure;
+
+    /**
+     * @return default supported languages and variants that can be used with {@link #builder(String)}
+     */
+    public static List<String> getDefaultConfigKeys() {
+        return asList("en", "ja", "ja.hankaku", "ja.zenkaku2");
+    }
 
     Configuration(File base, SymbolTable symbolTable, List<ValidatorConfiguration> validatorConfigs, String lang, boolean secure) {
         this.base = base;

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -223,8 +223,11 @@ public class Configuration implements Serializable, Cloneable {
         return new ConfigurationBuilder();
     }
 
-    public static ConfigurationBuilder builder(String lang) {
-        return new ConfigurationBuilder().setLanguage(lang);
+    public static ConfigurationBuilder builder(String key) {
+        int dotPos = key.indexOf('.');
+        ConfigurationBuilder builder = new ConfigurationBuilder().setLanguage(dotPos > 0 ? key.substring(0, dotPos) : key);
+        if (dotPos > 0) builder.setVariant(key.substring(dotPos+1));
+        return builder;
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
@@ -24,7 +24,10 @@ import cc.redpen.validator.section.*;
 import cc.redpen.validator.sentence.*;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Factory class of validators.
@@ -78,6 +81,18 @@ public class ValidatorFactory {
 
         // other
         registerValidator(JavaScriptValidator.class);
+    }
+
+    public static List<ValidatorConfiguration> getConfigurations(String lang) {
+        return validators.entrySet().stream().filter(e -> {
+            try {
+                List<String> supportedLanguages = e.getValue().newInstance().getSupportedLanguages();
+                return supportedLanguages.isEmpty() || supportedLanguages.contains(lang);
+            }
+            catch (IllegalAccessException | InstantiationException ex) {
+                throw new RuntimeException(ex);
+            }
+        }).map(e -> new ValidatorConfiguration(e.getKey())).collect(toList());
     }
 
     public static Validator getInstance(String validatorName) throws RedPenException {

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
@@ -20,29 +20,74 @@ package cc.redpen.validator;
 import cc.redpen.RedPenException;
 import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
+import cc.redpen.validator.section.*;
+import cc.redpen.validator.sentence.*;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Arrays.asList;
 
 /**
  * Factory class of validators.
  */
 public class ValidatorFactory {
-    private static final List<String> VALIDATOR_PACKAGES = new ArrayList<>();
+    private static final String validatorsPackage = Validator.class.getPackage().getName();
+    private static final List<String> VALIDATOR_PACKAGES = asList(validatorsPackage, validatorsPackage + ".sentence", validatorsPackage + ".section");
 
-    static {
-        addValidatorPackage("cc.redpen.validator");
-        addValidatorPackage("cc.redpen.validator.sentence");
-        addValidatorPackage("cc.redpen.validator.section");
+    static final Set<Class<? extends Validator>> defaultValidators = new HashSet<>();
+
+    public static void registerValidator(Class<? extends Validator> clazz) {
+        defaultValidators.add(clazz);
     }
 
-    // can be made public if package needs to be added outside RedPen.
-    private static void addValidatorPackage(String packageToAdd) {
-        VALIDATOR_PACKAGES.add(packageToAdd);
+    static {
+        // section
+        registerValidator(DuplicatedSectionValidator.class);
+        registerValidator(FrequentSentenceStartValidator.class);
+        registerValidator(ParagraphNumberValidator.class);
+        registerValidator(ParagraphStartWithValidator.class);
+        registerValidator(SectionLengthValidator.class);
+        registerValidator(UnexpandedAcronymValidator.class);
+        registerValidator(WordFrequencyValidator.class);
+
+        // sentence
+        registerValidator(CommaNumberValidator.class);
+        registerValidator(ContractionValidator.class);
+        registerValidator(DoubledJoshiValidator.class);
+        registerValidator(DoubledWordValidator.class);
+        registerValidator(DoubleNegativeValidator.class);
+        registerValidator(EndOfSentenceValidator.class);
+        registerValidator(HankakuKanaValidator.class);
+        registerValidator(HyphenationValidator.class);
+        registerValidator(InvalidExpressionValidator.class);
+        registerValidator(InvalidSymbolValidator.class);
+        registerValidator(InvalidWordValidator.class);
+        registerValidator(JapaneseStyleValidator.class);
+        registerValidator(KatakanaEndHyphenValidator.class);
+        registerValidator(KatakanaSpellCheckValidator.class);
+        registerValidator(NumberFormatValidator.class);
+        registerValidator(OkuriganaValidator.class);
+        registerValidator(ParenthesizedSentenceValidator.class);
+        registerValidator(QuotationValidator.class);
+        registerValidator(SentenceLengthValidator.class);
+        registerValidator(SpaceBeginningOfSentenceValidator.class);
+        registerValidator(SpaceBetweenAlphabeticalWordValidator.class);
+        registerValidator(SpellingValidator.class);
+        registerValidator(StartWithCapitalLetterValidator.class);
+        registerValidator(SuccessiveWordValidator.class);
+        registerValidator(SuggestExpressionValidator.class);
+        registerValidator(SymbolWithSpaceValidator.class);
+        registerValidator(WeakExpressionValidator.class);
+        registerValidator(WordNumberValidator.class);
+
+        // other
+        registerValidator(JavaScriptValidator.class);
     }
 
     public static Validator getInstance(String validatorName) throws RedPenException {

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidatorFactory.java
@@ -27,12 +27,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.*;
 
 /**
  * Factory class of validators.
  */
 public class ValidatorFactory {
+    private static final String validatorPackage = Validator.class.getPackage().getName();
+    private static final List<String> VALIDATOR_PACKAGES = asList(validatorPackage, validatorPackage + ".sentence", validatorPackage + ".section");
     static final Map<String, Validator> validators = new LinkedHashMap<>();
 
     public static void registerValidator(Class<? extends Validator> clazz) {
@@ -97,10 +100,24 @@ public class ValidatorFactory {
 
     public static Validator getInstance(ValidatorConfiguration config, Configuration globalConfig) throws RedPenException {
         Validator prototype = validators.get(config.getConfigurationName());
-        if (prototype == null) throw new RedPenException("There is no such validator: " + config.getConfigurationName());
-        Validator validator = createValidator(prototype.getClass());
+        Class<? extends Validator> validatorClass = prototype != null ? prototype.getClass() : loadPlugin(config.getConfigurationName());
+        Validator validator = createValidator(validatorClass);
         validator.preInit(config, globalConfig);
         return validator;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Validator> loadPlugin(String name) throws RedPenException {
+        for (String p : VALIDATOR_PACKAGES) {
+            try {
+                Class<? extends Validator> validatorClass = (Class)Class.forName(p + "." + name + "Validator");
+                registerValidator(validatorClass);
+                return validatorClass;
+            }
+            catch (ClassNotFoundException ignore) {
+            }
+        }
+        throw new RedPenException("There is no such validator: " + name);
     }
 
     private static Validator createValidator(Class<? extends Validator> clazz) {

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -227,7 +227,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addAvailbaleValidatorsForLanguage() throws Exception {
+    public void addAvailableValidatorsForLanguage() throws Exception {
         Configuration ja = Configuration.builder("ja").addAvailableValidatorConfigs().build();
         assertTrue(ja.getValidatorConfigs().contains(new ValidatorConfiguration("SentenceLength")));
         assertTrue(ja.getValidatorConfigs().contains(new ValidatorConfiguration("HankakuKana")));

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -225,4 +225,15 @@ public class ConfigurationTest {
         assertEquals(conf, conf2);
         assertEquals(conf.getTokenizer().getClass(), conf2.getTokenizer().getClass());
     }
+
+    @Test
+    public void addAvailbaleValidatorsForLanguage() throws Exception {
+        Configuration ja = Configuration.builder("ja").addAvailableValidatorConfigs().build();
+        assertTrue(ja.getValidatorConfigs().contains(new ValidatorConfiguration("SentenceLength")));
+        assertTrue(ja.getValidatorConfigs().contains(new ValidatorConfiguration("HankakuKana")));
+
+        Configuration en = Configuration.builder("en").addAvailableValidatorConfigs().build();
+        assertTrue(en.getValidatorConfigs().contains(new ValidatorConfiguration("SentenceLength")));
+        assertFalse(en.getValidatorConfigs().contains(new ValidatorConfiguration("HankakuKana")));
+    }
 }

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationTest.java
@@ -174,8 +174,7 @@ public class ConfigurationTest {
 
     @Test
     public void canBeCloned() throws Exception {
-        Configuration conf = Configuration.builder("ja")
-          .setVariant("hankaku")
+        Configuration conf = Configuration.builder("ja.hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
         Configuration clone = conf.clone();
@@ -193,8 +192,7 @@ public class ConfigurationTest {
 
     @Test
     public void equals() throws Exception {
-        Configuration conf = Configuration.builder("ja")
-          .setVariant("hankaku")
+        Configuration conf = Configuration.builder("ja.hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
         Configuration clone = conf.clone();
@@ -211,8 +209,7 @@ public class ConfigurationTest {
 
     @Test
     public void serializable() throws Exception {
-        Configuration conf = Configuration.builder("ja")
-          .setVariant("hankaku")
+        Configuration conf = Configuration.builder("ja.hankaku")
           .addValidatorConfig(new ValidatorConfiguration("SentenceLength")).build();
 
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/ValidatorFactoryTest.java
@@ -45,10 +45,10 @@ public class ValidatorFactoryTest {
     }
 
     @Test
-    public void customValidator() throws RedPenException {
-        ValidatorFactory.registerValidator(CustomValidator.class);
+    public void validatorPluginsAreCreatedAndRegistered() throws RedPenException {
         Configuration conf = Configuration.builder().addValidatorConfig(new ValidatorConfiguration("Custom")).build();
         assertEquals(CustomValidator.class, ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf).getClass());
+        assertTrue(ValidatorFactory.getConfigurations("en").contains(new ValidatorConfiguration("Custom")));
     }
 
     @Test(expected = RedPenException.class)


### PR DESCRIPTION
Introduces new API in ConfigurationBuilder that registers all available validators for a particular language.