### PR TITLE
SuggestExpressionValidator should do whole matches only

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static cc.redpen.util.StringUtils.isProbablyJapanese;
 import static java.lang.Character.isLetter;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -49,7 +50,7 @@ public final class SuggestExpressionValidator extends Validator {
             if (start < 0) return;
             int end = start + value.length();
             boolean hasWordBoundaries = (start == 0 || !isLetter(text.charAt(start - 1))) && (end == text.length() || !isLetter(text.charAt(end)));
-            if (hasWordBoundaries) {
+            if (isProbablyJapanese(text.charAt(start)) || hasWordBoundaries) {
                 addLocalizedErrorWithPosition(sentence, start, end, value, synonyms.get(value));
             }
         });

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SuggestExpressionValidator.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.lang.Character.isLetter;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
@@ -42,11 +43,14 @@ public final class SuggestExpressionValidator extends Validator {
 
     @Override
     public void validate(Sentence sentence) {
+        String text = sentence.getContent();
         synonyms.keySet().stream().forEach(value -> {
-            int startPosition = sentence.getContent().indexOf(value);
-            if (startPosition != -1) {
-                String suggested = synonyms.get(value);
-                addLocalizedErrorWithPosition(sentence, startPosition, startPosition + value.length(), value, suggested);
+            int start = text.indexOf(value);
+            if (start < 0) return;
+            int end = start + value.length();
+            boolean hasWordBoundaries = (start == 0 || !isLetter(text.charAt(start - 1))) && (end == text.length() || !isLetter(text.charAt(end)));
+            if (hasWordBoundaries) {
+                addLocalizedErrorWithPosition(sentence, start, end, value, synonyms.get(value));
             }
         });
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SymbolWithSpaceValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SymbolWithSpaceValidator.java
@@ -58,8 +58,7 @@ public class SymbolWithSpaceValidator extends Validator {
                 key = "Before";
             }
 
-            if (position < sentenceStr.length() - 1 && symbol.isNeedAfterSpace()
-                && !isWhitespace(sentenceStr.charAt(position + 1)) && isLetterOrDigit(sentenceStr.charAt(position + 1))) {
+            if (position < sentenceStr.length() - 1 && symbol.isNeedAfterSpace() && isLetterOrDigit(sentenceStr.charAt(position + 1))) {
                 key += "After";
             }
 

--- a/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/BaseValidatorTest.java
@@ -27,5 +27,9 @@ public abstract class BaseValidatorTest {
       .addSentence(new Sentence(sentrence, 1))
       .build();
   }
+
+  protected Sentence sentence(String text) {
+    return prepareSimpleDocument(text).getLastSection().getParagraph(0).getSentence(0);
+  }
 }
 

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidatorTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class SpaceBeginningOfSpenceValidatorTest {
+public class SpaceBeginningOfSentenceValidatorTest {
     @Test
     public void testProcessSentenceWithoutEndSpace() throws RedPenException {
         Configuration config = Configuration.builder()

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SuggestExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SuggestExpressionValidatorTest.java
@@ -45,6 +45,7 @@ public class SuggestExpressionValidatorTest extends BaseValidatorTest {
         Map<String, String> synonymSamples = new HashMap<>();
         synonymSamples.put("like", "such as");
         synonymSamples.put("info", "information");
+        synonymSamples.put("こんにちは", "良い一日");
         validator.setSynonyms(synonymSamples);
     }
 
@@ -78,6 +79,14 @@ public class SuggestExpressionValidatorTest extends BaseValidatorTest {
         validator.setErrorList(errors);
         validator.validate(sentence("the information."));
         assertEquals(0, errors.size());
+    }
+
+    @Test
+    public void japanese() {
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(sentence("こんにちは世界"));
+        assertEquals(1, errors.size());
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SuggestExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SuggestExpressionValidatorTest.java
@@ -19,7 +19,7 @@ package cc.redpen.validator.sentence;
 
 import cc.redpen.config.Configuration;
 import cc.redpen.config.ValidatorConfiguration;
-import cc.redpen.model.Sentence;
+import cc.redpen.validator.BaseValidatorTest;
 import cc.redpen.validator.ValidationError;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,67 +32,73 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 
-public class SuggestExpressionValidatorTest {
+public class SuggestExpressionValidatorTest extends BaseValidatorTest {
+    private SuggestExpressionValidator validator;
 
-    private SuggestExpressionValidator suggestExpressionValidator;
+    public SuggestExpressionValidatorTest() {
+        super("SuggestExpression");
+    }
 
     @Before
     public void init() {
-        suggestExpressionValidator = new SuggestExpressionValidator();
+        validator = new SuggestExpressionValidator();
         Map<String, String> synonymSamples = new HashMap<>();
         synonymSamples.put("like", "such as");
         synonymSamples.put("info", "information");
-        suggestExpressionValidator.setSynonyms(synonymSamples);
+        validator.setSynonyms(synonymSamples);
     }
 
     @Test
     public void testSynonym() {
-        Sentence str = new Sentence("it like a piece of a cake.", 0);
         List<ValidationError> errors = new ArrayList<>();
-        suggestExpressionValidator.setErrorList(errors);
-        suggestExpressionValidator.validate(str);
+        validator.setErrorList(errors);
+        validator.validate(sentence("it like a piece of a cake."));
         assertEquals(1, errors.size());
     }
 
     @Test
     public void testWithoutSynonym() {
-        Sentence str = new Sentence("it love a piece of a cake.", 0);
         List<ValidationError> errors = new ArrayList<>();
-        suggestExpressionValidator.setErrorList(errors);
-        suggestExpressionValidator.validate(str);
+        validator.setErrorList(errors);
+        validator.validate(sentence("it love a piece of a cake."));
         assertEquals(0, errors.size());
     }
 
     @Test
     public void testWithMultipleSynonyms() {
-        Sentence str = new Sentence("it like a the info.", 0);
         List<ValidationError> errors = new ArrayList<>();
-        suggestExpressionValidator.setErrorList(errors);
-        suggestExpressionValidator.validate(str);
+        validator.setErrorList(errors);
+        validator.validate(sentence("it like a the info."));
         assertEquals(2, errors.size());
     }
 
     @Test
-    public void testWitoutZeroLengthSentence() {
-        Sentence str = new Sentence("", 0);
+    public void matchWholeExpressionsOnly() {
         List<ValidationError> errors = new ArrayList<>();
-        suggestExpressionValidator.setErrorList(errors);
-        suggestExpressionValidator.validate(str);
+        validator.setErrorList(errors);
+        validator.validate(sentence("the information."));
+        assertEquals(0, errors.size());
+    }
+
+    @Test
+    public void testWitoutZeroLengthSentence() {
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(sentence(""));
         assertEquals(0, errors.size());
     }
 
     @Test
     public void testErrorMessageIsProperlyFormatted() {
-        Sentence str = new Sentence("Thank you for the info.", 0);
         List<ValidationError> errors = new ArrayList<>();
-        suggestExpressionValidator.setErrorList(errors);
-        suggestExpressionValidator.validate(str);
+        validator.setErrorList(errors);
+        validator.validate(sentence("Thank you for the info."));
         assertEquals(1, errors.size());
         assertEquals("Found invalid word \"info\". Use the synonym \"information\" instead.", errors.get(0).getMessage());
     }
 
     @Test
     public void initDoesNotFailIfDictionaryIsNotSpecified() throws Exception {
-        suggestExpressionValidator.preInit(new ValidatorConfiguration("SuggestExpression"), Configuration.builder().build());
+        validator.preInit(new ValidatorConfiguration("SuggestExpression"), Configuration.builder().build());
     }
 }


### PR DESCRIPTION
Otherwise if it suggests changing of "info" to "information", then it reports "**info**rmation" as error again.