### PR TITLE
Allow specifying minimum length of detected doubled words

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -72,7 +72,7 @@ public abstract class Validator {
         addDefaultProperties(keyValues);
     }
 
-    protected void addDefaultProperties(Object[] keyValues) {
+    protected void addDefaultProperties(Object...keyValues) {
         if (keyValues.length % 2 != 0) throw new IllegalArgumentException("Not enough values specified");
         for (int i = 0; i < keyValues.length; i+=2) {
             properties.put(keyValues[i].toString(), keyValues[i+1]);
@@ -220,8 +220,6 @@ public abstract class Validator {
         return (Set) properties.get(name);
     }
 
-    /** @deprecated Please use constructor with default properties instead, and then getXXX() methods */
-    @Deprecated
     protected Optional<String> getConfigAttribute(String name) {
         return Optional.ofNullable(config.getProperty(name));
     }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledWordValidatorTest.java
@@ -59,6 +59,38 @@ public class DoubledWordValidatorTest extends BaseValidatorTest {
     }
 
     @Test
+    public void noErrorsForShortWordsByDefault() throws RedPenException {
+        Document document = prepareSimpleDocument("A validator is a validator.");
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
+        assertEquals(1, errors.get(document).size());
+        assertEquals("Found repeated word \"validator\".", errors.get(document).get(0).getMessage());
+    }
+
+    @Test
+    public void minimumWordLengthIsConfigurable() throws RedPenException {
+        config.getValidatorConfigs().get(0).addProperty("min_len", "10");
+        Document document = prepareSimpleDocument("A validator is a validator.");
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
+        assertEquals(0, errors.get(document).size());
+    }
+
+    @Test
+    public void minimumWordLengthIsConfigurableForJapanese() throws RedPenException {
+        config = Configuration.builder("ja")
+          .addValidatorConfig(new ValidatorConfiguration(validatorName).addProperty("min_len", "5"))
+          .build();
+        Document document = prepareSimpleDocument("こんにちは！こんにちは！");
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
+        assertEquals(1, errors.get(document).size());
+    }
+
+    @Test
     public void testDoubledSkipListWord() throws RedPenException {
         Document document = prepareSimpleDocument("That is true, as far as I know.");
 
@@ -69,10 +101,8 @@ public class DoubledWordValidatorTest extends BaseValidatorTest {
 
     @Test
     public void testDoubledUserDefinedSkipWord() throws RedPenException {
-        config = Configuration.builder()
-                .addValidatorConfig(new ValidatorConfiguration(validatorName)
-                        .addProperty("list", "redpen,tool"))
-                .build();
+        config = Configuration.builder().addValidatorConfig(new ValidatorConfiguration(validatorName)
+          .addProperty("list", "redpen,tool")).build();
 
         Document document = prepareSimpleDocument("RedPen is RedPen right?");
 


### PR DESCRIPTION
This is useful for automatically skipping commas, "a", "an", "to" etc, without providing skip lists for all major languages.

For example, we don't have a skip list for Russian yet, but this change already fixes all incorrectly reported cases.