### PR TITLE
SpellingValidator must skip all separate punctuation characters

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
@@ -21,23 +21,15 @@ import cc.redpen.model.Sentence;
 import cc.redpen.tokenizer.TokenElement;
 
 public final class SpellingValidator extends SpellingDictionaryValidator {
-    private static String skipCharacters = "[\\!-/:-@\\[-`{-~]";
-
     @Override
     public void validate(Sentence sentence) {
         for (TokenElement token : sentence.getTokens()) {
-            String surface = normalize(token.getSurface());
-            if (surface.length() == 0) {
-                continue;
-            }
+            String surface = token.getSurface().toLowerCase();
+            if (surface.length() == 0 || surface.matches("\\P{L}+")) continue;
 
             if (dictionaryExists() && !inDictionary(surface)) {
                 addLocalizedErrorFromToken(sentence, token);
             }
         }
-    }
-
-    private String normalize(String token) {
-        return token.toLowerCase().replaceAll(skipCharacters, "");
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpellingValidatorTest.java
@@ -98,6 +98,32 @@ public class SpellingValidatorTest extends BaseValidatorTest {
     }
 
     @Test
+    public void nonLatin() throws RedPenException {
+        config = Configuration.builder("ru")
+                .addValidatorConfig(new ValidatorConfiguration(validatorName).addProperty("list", "привет"))
+                .build();
+
+        Document document = prepareSimpleDocument("Привет, мир!");
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
+        assertEquals(1, errors.get(document).size());
+    }
+
+    @Test
+    public void punctuationInsideOfWord() throws RedPenException {
+        config = Configuration.builder()
+                .addValidatorConfig(new ValidatorConfiguration(validatorName).addProperty("list", "can-do"))
+                .build();
+
+        Document document = prepareSimpleDocument("can-do");
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(singletonList(document));
+        assertEquals(0, errors.get(document).size());
+    }
+
+    @Test
     public void testPunctuation() throws RedPenException {
         RedPen redPen = new RedPen(config);
 


### PR DESCRIPTION
but keep them as part of words (e.g. hyphens or apostrophes)