### PR TITLE
adjust dependency scopes of redpen-server module

### DIFF
--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -159,7 +159,6 @@
             <artifactId>kuromoji-ipadic</artifactId>
             <version>0.9.0</version>
             <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -209,19 +209,19 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>9.2.1.v20140609</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>9.2.1.v20140609</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -172,21 +172,18 @@
             <artifactId>wink-component-test-support</artifactId>
             <version>1.3.0</version>
             <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-server</artifactId>
             <version>1.3.0</version>
             <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-json-provider</artifactId>
             <version>1.3.0</version>
             <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -209,25 +206,21 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>9.2.1.v20140609</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>9.2.1.v20140609</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-mock</artifactId>
             <version>2.0.8</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/redpen-server/pom.xml
+++ b/redpen-server/pom.xml
@@ -121,7 +121,6 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>org.eclipse.jetty, commons-cli, javax.servlet</includeGroupIds>
-                            <includeScope>provided</includeScope>
                             <!-- remove some files in order to decrease size -->
                             <excludes>*, about_files/*, META-INF/*</excludes>
                             <outputDirectory>

--- a/redpen-server/src/main/java/RedPenRunner.java
+++ b/redpen-server/src/main/java/RedPenRunner.java
@@ -91,7 +91,12 @@ public class RedPenRunner {
 
         WebAppContext webapp = new WebAppContext();
         webapp.setContextPath(contextPath);
-        webapp.setWar(location.toExternalForm());
+        if (location.toExternalForm().endsWith("redpen-server/target/classes/")) {
+            // use redpen-server/target/redpen-server instead, because target/classes doesn't contain web resources.
+            webapp.setWar(location.toExternalForm() + "../redpen-server/");
+        } else {
+            webapp.setWar(location.toExternalForm());
+        }
 
         handlerList.addHandler(webapp);
         server.setHandler(handlerList);


### PR DESCRIPTION
redpen-server should depend on commons-cli and jetty in "compile" scope.
redpen-server doesn't run without those libraries.