### PR TITLE
Lexing comments in more compatible way

### DIFF
--- a/redpen-core/src/test/java/cc/redpen/parser/latex/LexerTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/latex/LexerTest.java
@@ -28,10 +28,29 @@ import static cc.redpen.parser.latex.Assert.*;
 
 public class LexerTest {
     @Test
-    public void testCommentShouldNotAppear() {
-        final String corpse = "% This is a comment\n";
-        final List<Token> tokens = Lexer.on(corpse).parse();
-        assertEquals(0, tokens.size());
+    public void testCommentShouldAppearAsWhitespace() {
+        final String corpse = "This is a sentence.\n% This is a comment\nAnd this is another sentence.\n";
+        assertTokensEqual(
+            Arrays.asList(
+                token("TEXTILE", "This is a sentence.\n", new Position(1,0)),
+                token("TEXTILE", "\n", new Position(2,0)),
+                token("TEXTILE", "And this is another sentence.\n", new Position(3,0))
+                ),
+            Lexer.on(corpse).parse()
+        );
+    }
+
+
+    @Test
+    public void testCommentWorksAgainstNewline() {
+        final String corpse = "This is a sentence.\n%\nThis is a line should be concatenated.\n";
+        assertTokensEqual(
+            Arrays.asList(
+                token("TEXTILE", "This is a sentence.\n", new Position(1,0)),
+                token("TEXTILE", "This is a line should be concatenated.\n", new Position(3,0))
+                ),
+            Lexer.on(corpse).parse()
+        );
     }
 
     @Test


### PR DESCRIPTION
Hello, I've noticed the LaTeX lexer doesn't process comment lines properly, giving off issues like #626.

I think more proper ways of processing comment lines should boil down to the following points:

1) Treat a comment line as a newline (or whitespace).
2) If one trails exactly one newline, ignore the line completely.

So I have changed comment handling in the lexer.
Please review and hopefully merge.
Thanks.

Changes:
- src/main/java/cc/redpen/parser/latex/Lexer.java: Changing comment handling.
- src/test/java/cc/redpen/parser/latex/LexerTest.java: Adding tests.