### PR TITLE
[WIP] Recycling Validators

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -133,6 +133,7 @@ public class RedPen {
         runDocumentValidators(documents, docErrorsMap);
         runSectionValidators(documents, docErrorsMap);
         runSentenceValidators(documents, docErrorsMap);
+        validators.forEach(e -> {e.clear();});
         return docErrorsMap;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/JavaScriptValidator.java
@@ -145,6 +145,13 @@ public class JavaScriptValidator extends Validator {
         }
     }
 
+    @Override
+    public void clear() {
+        for (Script js : scripts) {
+            call(js, "clear");
+        }
+    }
+
     private Map<Script, Map<String, Boolean>> functionExistenceMap = new HashMap<>();
 
    Script currentJS;

--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -131,6 +131,13 @@ public abstract class Validator {
     }
 
     /**
+     * reset internal state for reusing.
+     * {@link cc.redpen.validator.Validator} provides empty implementation. Validator implementation maintains some internal state can override this method.
+     */
+    public void clear() {
+    }
+
+    /**
      * Return an array of languages supported by this validator
      * {@link cc.redpen.validator.Validator} provides empty implementation. Validator implementation validates sections can override this method.
      *

--- a/redpen-core/src/main/java/cc/redpen/validator/section/DuplicatedSectionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/DuplicatedSectionValidator.java
@@ -80,6 +80,11 @@ final public class DuplicatedSectionValidator extends Validator {
         }
     }
 
+    @Override
+    public void clear() {
+        sectionVectors.clear();
+    }
+
     private double calcCosine(Map<String, Integer> targetVector,
             Map<String, Integer> argumentVector) {
         int innerProduct = 0;

--- a/redpen-core/src/main/java/cc/redpen/validator/section/FrequentSentenceStartValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/FrequentSentenceStartValidator.java
@@ -80,4 +80,9 @@ public class FrequentSentenceStartValidator extends Validator {
             }
         }
     }
+
+    @Override
+    public void clear() {
+        sentenceStartHistogram.clear();
+    }
 }

--- a/redpen-core/src/main/java/cc/redpen/validator/section/UnexpandedAcronymValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/UnexpandedAcronymValidator.java
@@ -60,6 +60,12 @@ public class UnexpandedAcronymValidator extends SpellingDictionaryValidator {
         acronymJoiningWords.add("&");
     }
 
+    @Override
+    public void clear() {
+        expandedAcronyms.clear();
+        contractedAcronyms.clear();
+    }
+
     private void processSentence(Sentence sentence) {
         List<String> sequence = new ArrayList<>();
         for (TokenElement token : sentence.getTokens()) {

--- a/redpen-core/src/main/java/cc/redpen/validator/section/WordFrequencyValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/WordFrequencyValidator.java
@@ -65,6 +65,11 @@ public class WordFrequencyValidator extends SpellingDictionaryValidator {
         initDeviations(referenceWordFrequencies, referenceWordDeviations);
     }
 
+    @Override
+    public void clear() {
+        documentWordOccurances.clear();
+    }
+
     /**
      * Add the words in the sentence to the word frequency histogram
      */

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/ContractionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/ContractionValidator.java
@@ -132,6 +132,12 @@ final public class ContractionValidator extends Validator {
     }
 
     @Override
+    public void clear() {
+        foundContractionNum = 0;
+        foundNonContractionNum = 0;
+    }
+
+    @Override
     public void validate(Sentence sentence) {
         for (TokenElement token : sentence.getTokens()) {
             String surface = token.getSurface().toLowerCase();

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseStyleValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseStyleValidator.java
@@ -41,6 +41,12 @@ public class JapaneseStyleValidator extends Validator {
     private int desumasuCount = 0;
 
     @Override
+    public void clear() {
+        dearuCount = 0;
+        desumasuCount = 0;
+    }
+
+    @Override
     public void preValidate(Sentence sentence) {
         // match content
         dearuCount += countMatch(sentence, DEARU_PATTERN);

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
@@ -72,6 +72,12 @@ import static java.util.Collections.singletonList;
     }
 
     @Override
+    public void clear() {
+        katakanaWordFrequencies.clear();
+        dic.clear();
+    }
+
+    @Override
     public List<String> getSupportedLanguages() {
         return singletonList(Locale.JAPANESE.getLanguage());
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
@@ -52,4 +52,9 @@ public final class SpaceBeginningOfSentenceValidator extends Validator {
         List<Sentence> list = sentencePositions.get(sentence.getLineNumber());
         list.add(sentence);
     }
+
+    @Override
+    public void clear() {
+        sentencePositions.clear();
+    }
 }


### PR DESCRIPTION
Hello, I've noticed some validators hold their state across REST-based requests.
I think they should be discarded per request. I have done this.
This PR intends to resolve #621.

Please review and hopefully merge.
Thanks.
-t

Changes:
- redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java: Requesting isolated RedPenService instances.
- redpen-server/src/main/java/cc/redpen/server/api/RedPenService.java: Clearing cache upon request of isolated instances.
- redpen-server/src/test/java/cc/redpen/server/api/RedPenServiceTest.java: Adding test case.