### PR TITLE
Make contents in list elements tokenized in Document.builder

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/model/Document.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Document.java
@@ -257,6 +257,9 @@ public class Document implements Iterable<Section>, Serializable {
                 throw new IllegalStateException("No section to add a sentence");
             }
             Section lastSection = getSection(sections.size() - 1);
+            for(Sentence sentence : contents) {
+                sentence.setTokens(tokenizer.tokenize(sentence.getContent()));
+            }
             lastSection.appendListElement(level, contents);
             return this;
         }

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -582,6 +582,22 @@ public class MarkdownParserTest extends BaseParserTest {
     }
 
     @Test
+    public void testAccessTokensInList()
+            throws UnsupportedEncodingException {
+        String sampleText = "";
+        sampleText += "# About Gunma\n";
+        sampleText += "* located at west of Saitama\n";
+        sampleText += "* near Tokyo";
+
+        Document doc = createFileContent(sampleText);
+        Section section = doc.getSection(doc.size() - 1);
+        ListBlock list = section.getListBlock(0);
+        assertEquals(2, list.getNumberOfListElements());
+        assertEquals(5, list.getListElement(0).getSentence(0).getTokens().size());
+        assertEquals(2, list.getListElement(1).getSentence(0).getTokens().size());
+    }
+
+    @Test
     public void testDocumentWithListWithoutPeriod()
             throws UnsupportedEncodingException {
         String sampleText = "";


### PR DESCRIPTION
This patch fixes #638. 