### PR TITLE
Addition of Tokenizer UI to redpen-server

### DIFF
--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -26,6 +26,9 @@ import cc.redpen.config.SymbolType;
 import cc.redpen.formatter.Formatter;
 import cc.redpen.model.Document;
 import cc.redpen.parser.DocumentParser;
+import cc.redpen.tokenizer.JapaneseTokenizer;
+import cc.redpen.tokenizer.RedPenTokenizer;
+import cc.redpen.tokenizer.WhiteSpaceTokenizer;
 import cc.redpen.util.FormatterUtils;
 import cc.redpen.util.LanguageDetector;
 import cc.redpen.validator.ValidationError;
@@ -64,7 +67,7 @@ public class RedPenResource {
     /**
      * Detect language of document
      *
-     * @param document       the source text of the document
+     * @param document the source text of the document
      */
     @Path("/language")
     @POST
@@ -91,10 +94,10 @@ public class RedPenResource {
     @Produces(MediaType.APPLICATION_JSON)
     @WinkAPIDescriber.Description("Validate a document and return any redpen errors")
     public String validateDocument(@FormParam("document") @DefaultValue("") String document,
-                                     @FormParam("documentParser") @DefaultValue(DEFAULT_DOCUMENT_PARSER) String documentParser,
-                                     @FormParam("lang") @DefaultValue(DEFAULT_CONFIGURATION) String lang,
-                                     @FormParam("format") @DefaultValue(DEFAULT_FORMAT) String format,
-                                     @FormParam("config") String config) throws RedPenException {
+                                   @FormParam("documentParser") @DefaultValue(DEFAULT_DOCUMENT_PARSER) String documentParser,
+                                   @FormParam("lang") @DefaultValue(DEFAULT_CONFIGURATION) String lang,
+                                   @FormParam("format") @DefaultValue(DEFAULT_FORMAT) String format,
+                                   @FormParam("config") String config) throws RedPenException {
 
         LOG.info("Validating document");
         RedPen redPen;
@@ -214,6 +217,30 @@ public class RedPenResource {
         }
 
         return formatter.format(parsedDocument, errors);
+    }
+
+    /**
+     * Tokenize some text and return the tokens
+     *
+     * @param document the source text of the document
+     */
+    @Path("/tokenize")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @WinkAPIDescriber.Description("Tokenize a document")
+    public JSONObject tokenize(@FormParam("document") @DefaultValue("") String document,
+                               @FormParam("lang") @DefaultValue(DEFAULT_CONFIGURATION) String lang) throws JSONException {
+        RedPenTokenizer tokenizer;
+        switch (lang == null ? "en" : lang) {
+            case "ja":
+                tokenizer = new JapaneseTokenizer();
+                break;
+            default:
+                tokenizer = new WhiteSpaceTokenizer();
+                break;
+        }
+
+        return new JSONObject().put("tokens", tokenizer.tokenize(document == null ? "" : document));
     }
 
     private String getOrDefault(JSONObject json, String property, String defaultValue) {

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -49,6 +49,10 @@ a:hover {
     cursor: pointer;
 }
 
+a:visited {
+    color: rgb(62, 63, 58);
+}
+
 label {
     margin-bottom: 0px;
     min-height: 10px;
@@ -313,6 +317,40 @@ input[type="radio"], input[type="checkbox"] {
     padding-top: 6px;
     cursor: pointer;
     color: #9E9E9E;
+}
+
+#redpen-token-editor {
+    color: #333;
+    background-color: #E8F5E9;
+    font-size: 16px;
+    height: 96px;
+    padding: 12px;
+    width: 100%;
+    z-index: 2;
+    outline: none;
+}
+
+#redpen-rule-editor {
+    color: #333;
+    background-color: #E8F5E9;
+    font-size: 16px;
+    height: 100%;
+    padding: 12px;
+    width: 40%;
+    z-index: 2;
+    outline: none;
+}
+
+.nikkeib2b-token-stream {
+}
+
+.nikkeib2b-token {
+    display: inline-block;
+    padding: 4px;
+    border: solid 1px rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+    margin: 2px;
+    background-color: #FFECB3;
 }
 
 .redpen-option-selected {

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -191,7 +191,7 @@
             <div class="navbar-collapse collapse" id="navbar-main">
                 <ul class="nav navbar-nav">
                     <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="themes">Examples
+                        <a  href="#validator"  class="dropdown-toggle" data-toggle="dropdown" id="themes">Validator
                             <span class="caret"></span></a>
                         <ul class="dropdown-menu" aria-labelledby="themes">
                             <li><a onclick="pasteSampleText('en')">English Text</a></li>
@@ -205,6 +205,12 @@
                         </ul>
                     </li>
                     <li>
+                        <a href="#tokenizer" onclick="setView('tokenizer')">Tokenizer</a>
+                    </li>
+                    <!--<li>-->
+                        <!--<a href="#rule-editor" onclick="setView('rule-editor')">Rule Tester</a>-->
+                    <!--</li>-->
+                    <li>
                         <a href="/rest" target="_blank">Server API</a>
                     </li>
                     <li>
@@ -217,7 +223,7 @@
     </div>
 </section>
 
-<section id="redpen-validator-test" class="main">
+<section id="redpen-view-validator" class="main">
     <div class="container redpen-fixed-container">
 
         <div class="row redpen-header-row">
@@ -288,6 +294,49 @@
                 <div id="redpen-results-json" style="display:none" class="well">
                 </div>
             </div>
+        </div>
+    </div>
+</section>
+
+<section id="redpen-view-tokenizer" class="main" style="display:none">
+    <div class="container redpen-fixed-container">
+        <div class="row redpen-header-row">
+            <div class="col-md-12">
+                <h1><span class="redpen-red">Red</span>Pen Tokenizer Testbed</h1>
+                <p>Enter some text to discover how it is tokenized.
+                </p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-10">
+                <textarea id="redpen-token-editor" spellcheck="false"></textarea>
+            </div>
+            <div class="col-md-2">
+                <input type="radio" name="redpen-token-lang" value="ja" checked>&nbsp;JA<br/>
+                <input type="radio" name="redpen-token-lang" value="en">&nbsp;EN/RU<br/>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div id="redpen-token-output"></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+
+<section id="redpen-view-rule-editor" class="main" style="display:none">
+    <div class="container redpen-fixed-container">
+        <div class="row redpen-header-row">
+            <div class="col-md-7">
+                <h1><span class="redpen-red">Red</span>Pen Rule Editor</h1>
+                <p>Enter your rule to see how it is evaluated.
+                </p>
+            </div>
+        </div>
+        <div class="row redpen-fixed-row">
+            <textarea id="redpen-rule-editor" spellcheck="false"></textarea>
         </div>
     </div>
 </section>

--- a/redpen-server/src/main/webapp/js/redpen.js
+++ b/redpen-server/src/main/webapp/js/redpen.js
@@ -47,13 +47,13 @@ var redpen = (function ($) {
         });
     };
 
-    this.setBaseUrl = function(url) {
+    this.setBaseUrl = function (url) {
         baseUrl = url;
     };
 
     this.detectLanguage = function (text, callback) {
         if (text) {
-            doAPICall('document/language', {document: text}, function(data) {
+            doAPICall('document/language', {document: text}, function (data) {
                 callback(data.key);
             }, 'POST');
         }
@@ -69,6 +69,10 @@ var redpen = (function ($) {
         doAPICall('config/redpens', {}, callback);
     };
 
+    // tokenize the document {document: text, lang: [en|ja..]}
+    this.tokenize = function (parameters, callback) {
+        doAPICall('document/tokenize', parameters, callback, "POST");
+    };
 
     // validate the document {document: text, lang: [en|ja..]}
     this.validateJSON = function (parameters, callback) {
@@ -84,9 +88,10 @@ var redpen = (function ($) {
                 }
             }
         }).fail(function (err) {
-                console.log(err);
-            });
+            console.log(err);
+        });
     };
+
 
     return this;
 })(jQuery);


### PR DESCRIPTION
This change adds an extra tab to the redpen web UI that lets a user explore how the Japanese and white-space tokenizers break up words, and what attributes they reveal.

This is related to #614 