### PR TITLE
Number expresions should not precede kanjis

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidator.java
@@ -30,11 +30,11 @@ import static java.util.Collections.singletonList;
 
 public class JapaneseNumberExpressionValidator extends Validator {
     private final List<Pattern> patternsNumeric = Arrays.asList(
-        Pattern.compile("[一二三四五六七八九０-９][一二三四五六七八九０-９.．〜、]*[つの]"),
+        Pattern.compile("(?<![\\u4e00-\\u9faf])[一二三四五六七八九０-９][一二三四五六七八九０-９.．〜、]*[つの]"),
         Pattern.compile("(ひと|ふた|[みよむや]っ|いつ|ここの)つ")
     );
     private final List<Pattern> patternsNumericZenkaku = Arrays.asList(
-        Pattern.compile("[一二三四五六七八九0-9][一二三四五六七八九0-9.．〜、]*[つの]"),
+        Pattern.compile("(?<![\\u4e00-\\u9faf])[一二三四五六七八九0-9][一二三四五六七八九0-9.．〜、]*[つの]"),
         Pattern.compile("(ひと|ふた|[みよむや]っ|いつ|ここの)つ")
     );
     private final List<Pattern> patternsKansuji = Arrays.asList(
@@ -42,7 +42,7 @@ public class JapaneseNumberExpressionValidator extends Validator {
         Pattern.compile("(ひと|ふた|[みよむや]っ|いつ|ここの)つ")
     );
     private final List<Pattern> patternsHiragana = Arrays.asList(
-        Pattern.compile("[一二三四五六七八九0-9０-９][一二三四五六七八九0-9０-９.．〜、]*[つの]")
+        Pattern.compile("(?<![\\u4e00-\\u9faf])[一二三四五六七八九0-9０-９][一二三四五六七八九0-9０-９.．〜、]*[つの]")
     );
 
     public JapaneseNumberExpressionValidator() {

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidatorTest.java
@@ -145,6 +145,24 @@ public class JapaneseNumberExpressionValidatorTest {
     }
 
     @Test
+    public void testFailureCase() throws RedPenException {
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("JapaneseNumberExpression"))
+                .build();
+
+        List<Document> documents = new ArrayList<>();documents.add(
+                Document.builder(new JapaneseTokenizer())
+                        .addSection(1)
+                        .addParagraph()
+                        .addSentence(new Sentence("SuccessiveWord は同一の単語が連続して使用されたときにエラーを出力します。", 1))
+                        .build());
+
+        RedPen redPen = new RedPen(config);
+        List<ValidationError> errors = redPen.validate(documents).get(documents.get(0));
+        Assert.assertEquals(0, errors.size());
+    }
+
+    @Test
     public void testVoid() throws RedPenException {
         Configuration config = Configuration.builder("ja")
                 .addValidatorConfig(new ValidatorConfiguration("JapaneseNumberExpression"))


### PR DESCRIPTION
Hello, I've fixed JapaneseNumberExpression so that it does not look into chained kanjis.
This PR intends to resolve #659 .
Please review and merge.
Thanks.
-t

Changes:
- redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidator.java: Regex fixup.
- redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseNumberExpressionValidatorTest.java: Added test case.