### PR TITLE
Allowing non-top headers to start document

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/section/GappedSectionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/GappedSectionValidator.java
@@ -35,14 +35,18 @@ final public class GappedSectionValidator extends Validator {
         int seen = 0;
         for (Section s: document) {
             final int current = s.getLevel();
-            if (current <= seen) {
-                seen = current;
-            } else {
-                if (current == seen + 1) {
+            if (seen > 0) {
+                if (current <= seen) {
                     seen = current;
                 } else {
-                    addLocalizedError(s.getJoinedHeaderContents(), current, seen + 1);
+                    if (current == seen + 1) {
+                        seen = current;
+                    } else {
+                        addLocalizedError(s.getJoinedHeaderContents(), s.getJoinedHeaderContents().getContent(), current, seen + 1);
+                    }
                 }
+            } else {
+                seen = current;
             }
         }
     }

--- a/redpen-core/src/test/java/cc/redpen/validator/section/GappedSectionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/GappedSectionValidatorTest.java
@@ -70,4 +70,22 @@ public class GappedSectionValidatorTest {
 
         assertEquals(0, errors.size());
     }
+
+    @Test
+    public void testFailureCase() {
+        Document document =
+                Document.builder()
+                        .addSection(2)
+                        .addSectionHeader("Section 1.1")
+                        .addSection(3)
+                        .addSectionHeader("Section 1.1.1")
+                        .build();
+
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(document);
+
+        assertEquals(0, errors.size());
+    }
+
 }


### PR DESCRIPTION
Hello, I've fixed GappedSection so that it allows non-top headers to start document.
This PR intends to resolve #657.
Please review and merge.
Thanks.
-t

Changes:
- redpen-core/src/main/java/cc/redpen/validator/section/GappedSectionValidator.java: Latching on the first header level.
- redpen-core/src/test/java/cc/redpen/validator/section/GappedSectionValidatorTest.java: Added test case.