### PR TITLE
DoubledJoshi tunables

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
@@ -59,6 +59,9 @@ public class DoubledJoshiValidator extends Validator {
                         if ("格助詞".equals(t.get(1)) && "を".equals(s)) {
                             continue;
                         }
+                        if ("接続助詞".equals(t.get(1)) && "て".equals(s)) {
+                            continue;
+                        }
                     }
                     vec.add(new Pair<>(s, i));
                 }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
@@ -56,6 +56,9 @@ public class DoubledJoshiValidator extends Validator {
                         if ("連体化".equals(t.get(1)) && "の".equals(s)) {
                             continue;
                         }
+                        if ("格助詞".equals(t.get(1)) && "を".equals(s)) {
+                            continue;
+                        }
                     }
                     vec.add(new Pair<>(s, i));
                 }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java
@@ -23,6 +23,7 @@ import cc.redpen.validator.Validator;
 import cc.redpen.util.Pair;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -33,6 +34,8 @@ import static java.util.Collections.singletonList;
  * Note: this validator works only for Japanese texts.
  */
 public class DoubledJoshiValidator extends Validator {
+    private static final Pattern SEPARATOR_PATTERN = Pattern.compile("[、,，]");
+
     public DoubledJoshiValidator() {
         super();
         addDefaultProperties("list", emptySet());
@@ -65,8 +68,10 @@ public class DoubledJoshiValidator extends Validator {
                     }
                     vec.add(new Pair<>(s, i));
                 }
+                ++i;
+            } else if (SEPARATOR_PATTERN.matcher(s).find()) {
+                ++i;
             }
-            ++i;
         }
 
         final Map<String, Integer> seen = new HashMap<>();
@@ -76,7 +81,7 @@ public class DoubledJoshiValidator extends Validator {
             final String p = e.first;
             final int q = e.second;
             if (seen.containsKey(p)) {
-                if ((q - seen.get(p)) < mininumDistance) {
+                if ((q - seen.get(p)) <= mininumDistance) {
                     addLocalizedError(sentence, p);
                 }
             }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -106,6 +106,24 @@ public class DoubledJoshiValidatorTest {
     }
 
     @Test
+    public void testMinDistanceBorder() throws Exception {
+        List<Document> documents = new ArrayList<>();
+        documents.add(Document.builder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence(new Sentence("iPhoneと、Androidと。", 1))
+                .build());
+
+        Configuration config = Configuration.builder("ja")
+            .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addProperty("min_dist", 2))
+                .build();
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(1, errors.get(documents.get(0)).size());
+    }
+
+    @Test
     public void testRelaxedModeRentaikaRule() throws Exception {
         List<Document> documents = new ArrayList<>();
         documents.add(Document.builder(new JapaneseTokenizer())

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -106,7 +106,7 @@ public class DoubledJoshiValidatorTest {
     }
 
     @Test
-    public void testRelaxedMode() throws Exception {
+    public void testRelaxedModeRentaikaRule() throws Exception {
         List<Document> documents = new ArrayList<>();
         documents.add(Document.builder(new JapaneseTokenizer())
                 .addSection(1)
@@ -123,4 +123,21 @@ public class DoubledJoshiValidatorTest {
         assertEquals(0, errors.get(documents.get(0)).size());
     }
 
+    @Test
+    public void testRelaxedModeKakujoshiRule() throws Exception {
+        List<Document> documents = new ArrayList<>();
+        documents.add(Document.builder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence(new Sentence("オブジェクトを返す関数を公開する。", 1))
+                .build());
+
+        Configuration config = Configuration.builder("ja")
+            .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addProperty("relaxed", true))
+                .build();
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(0, errors.get(documents.get(0)).size());
+    }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -104,4 +104,23 @@ public class DoubledJoshiValidatorTest {
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         assertEquals(0, errors.get(documents.get(0)).size());
     }
+
+    @Test
+    public void testRelaxedMode() throws Exception {
+        List<Document> documents = new ArrayList<>();
+        documents.add(Document.builder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence(new Sentence("この製品の発表の動画はこちらです。", 1))
+                .build());
+
+        Configuration config = Configuration.builder("ja")
+            .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addProperty("relaxed", true))
+                .build();
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(0, errors.get(documents.get(0)).size());
+    }
+
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -140,4 +140,22 @@ public class DoubledJoshiValidatorTest {
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         assertEquals(0, errors.get(documents.get(0)).size());
     }
+
+    @Test
+    public void testRelaxedModeConjunctionRule() throws Exception {
+        List<Document> documents = new ArrayList<>();
+        documents.add(Document.builder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence(new Sentence("このあたりは実際に試していただいて決定すると良いでしょう。", 1))
+                .build());
+
+        Configuration config = Configuration.builder("ja")
+            .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addProperty("relaxed", true))
+                .build();
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(0, errors.get(documents.get(0)).size());
+    }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java
@@ -87,4 +87,21 @@ public class DoubledJoshiValidatorTest {
         assertEquals(0, errors.get(documents.get(0)).size());
     }
 
+    @Test
+    public void testMinDistance() throws Exception {
+        List<Document> documents = new ArrayList<>();
+        documents.add(Document.builder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence(new Sentence("iPhoneと、Androidと。", 1))
+                .build());
+
+        Configuration config = Configuration.builder("ja")
+            .addValidatorConfig(new ValidatorConfiguration("DoubledJoshi").addProperty("min_dist", 1))
+                .build();
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(0, errors.get(documents.get(0)).size());
+    }
 }


### PR DESCRIPTION
Hello, I've added some tunables (inspired on textlint) to the DoubledJoshi validator.

Tunables are:
 * min_distance: Minimum distance allowed between repeated joshies (default: Integer.MAX_VALUE; no repeated joshies allowed within a sentence.)
 * relaxed: Allows certain form of constructs involving doubled joshies. (default: false)

Please review and merge.
Thanks.

Changes:
* redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledJoshiValidator.java: Added tunables
* redpen-core/src/test/java/cc/redpen/validator/sentence/DoubledJoshiValidatorTest.java: Added test cases.