### PR TITLE
Ignoring LaTeX \footnote

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/parser/latex/StreamParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/latex/StreamParser.java
@@ -131,7 +131,7 @@ public class StreamParser {
             final List<Token> o = new ArrayList<>();
             final Deque<Token> q = new ArrayDeque<>(tokens);
             final Pattern interests = Pattern.compile("(?:caption|part|(?:sub)*(chapter|section|paragraph)|item|title)\\*?");
-            final Pattern ignores = Pattern.compile(".?(?:space|fill)\\*?|phantom|documentclass|usepackage|author|date|label|ref|cite|biblio.*|includegraphics");
+            final Pattern ignores = Pattern.compile(".?(?:space|fill)\\*?|phantom|documentclass|usepackage|author|date|label|ref|cite|biblio.*|includegraphics|footnote");
             try {
                 while (true) {
                     final Token t = q.removeFirst();

--- a/redpen-core/src/test/java/cc/redpen/parser/latex/StreamParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/latex/StreamParserTest.java
@@ -201,7 +201,7 @@ public class StreamParserTest {
 
         for (String t:
                  Arrays.asList(
-                     "hfill", "hfill*", "vfill", "vfill*", "phantom", "documentclass", "usepackage", "author", "date", "label", "cite", "biblio*whatever*", "includegraphics"
+                     "hfill", "hfill*", "vfill", "vfill*", "phantom", "documentclass", "usepackage", "author", "date", "label", "cite", "biblio*whatever*", "includegraphics", "footnote"
                  )) {
             tokens.add(token("CONTROL", t));
             tokens.addAll(garbage);


### PR DESCRIPTION
Hello,
I've changed LaTeX parser so that it ignores the \footnote command.
Please review and hopefully merge.
Thank you.
-t

Changes:
- redpen-core/src/main/java/cc/redpen/parser/latex/StreamParser.java: Adding \footnote to ignore list.
- redpen-core/src/test/java/cc/redpen/parser/latex/StreamParserTest.java: Adding test case.