### PR TITLE
Enhance SpaceBetweenAlphabeticalWordValidator

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -213,7 +213,11 @@ public abstract class Validator {
     }
 
     protected String getString(String name) {
-        return config.getProperties().getOrDefault(name, (String) defaultProps.get(name));
+        if(config != null){
+            return config.getProperties().getOrDefault(name, (String) defaultProps.get(name));
+        }else{
+            return (String) defaultProps.get(name);
+        }
     }
 
     protected boolean getBoolean(String name) {

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
@@ -41,8 +41,8 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
 
     public SpaceBetweenAlphabeticalWordValidator() {
         super("forbidden", false, // Spaces are enforced (false) or forbidden (true)
-              "skip_before_chars", "",
-              "skip_after_chars", "");
+              "skip_before", "",
+              "skip_after", "");
     }
 
     @Override public List<String> getSupportedLanguages() {
@@ -78,7 +78,7 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
     // TODO: need refactoring...
     private boolean notHasWhiteSpaceBeforeLeftParenthesis(char prevCharacter, char character) {
         return !StringUtils.isBasicLatin(prevCharacter)
-                && getString("skip_before_chars").indexOf(prevCharacter) == -1
+                && getString("skip_before").indexOf(prevCharacter) == -1
                 && prevCharacter != leftParenthesis
                 && prevCharacter != comma
                 && (prevCharacter != rightParenthesis && rightParenthesis != '）') // For handling multi-byte Parenthesis
@@ -88,7 +88,7 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
 
     private boolean notHasWhiteSpaceAfterRightParenthesis(char prevCharacter, char character) {
         return !StringUtils.isBasicLatin(character)
-                && getString("skip_after_chars").indexOf(character) == -1
+                && getString("skip_after").indexOf(character) == -1
                 && character != rightParenthesis
                 && (character != leftParenthesis && leftParenthesis != '（')  // For handling multi-byte Parenthesis
                 && character != comma

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
@@ -78,7 +78,7 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
         return !StringUtils.isBasicLatin(prevCharacter)
                 && prevCharacter != leftParenthesis
                 && prevCharacter != comma
-                && (prevCharacter != rightParenthesis && rightParenthesis != '（') // For handling multi-byte Parenthesis
+                && (prevCharacter != rightParenthesis && rightParenthesis != '）') // For handling multi-byte Parenthesis
                 && StringUtils.isBasicLatin(character)
                 && Character.isLetter(character);
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidator.java
@@ -40,7 +40,9 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
     private final Pattern pat = Pattern.compile(shard + "\\s+(" + word + ")\\s+" + shard);
 
     public SpaceBetweenAlphabeticalWordValidator() {
-        super("forbidden", false); // Spaces are enforced (false) or forbidden (true)
+        super("forbidden", false, // Spaces are enforced (false) or forbidden (true)
+              "skip_before_chars", "",
+              "skip_after_chars", "");
     }
 
     @Override public List<String> getSupportedLanguages() {
@@ -76,6 +78,7 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
     // TODO: need refactoring...
     private boolean notHasWhiteSpaceBeforeLeftParenthesis(char prevCharacter, char character) {
         return !StringUtils.isBasicLatin(prevCharacter)
+                && getString("skip_before_chars").indexOf(prevCharacter) == -1
                 && prevCharacter != leftParenthesis
                 && prevCharacter != comma
                 && (prevCharacter != rightParenthesis && rightParenthesis != '）') // For handling multi-byte Parenthesis
@@ -85,6 +88,7 @@ public class SpaceBetweenAlphabeticalWordValidator extends Validator {
 
     private boolean notHasWhiteSpaceAfterRightParenthesis(char prevCharacter, char character) {
         return !StringUtils.isBasicLatin(character)
+                && getString("skip_after_chars").indexOf(character) == -1
                 && character != rightParenthesis
                 && (character != leftParenthesis && leftParenthesis != '（')  // For handling multi-byte Parenthesis
                 && character != comma

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
@@ -206,6 +206,36 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
         assertEquals(1, errors.size());
     }
 
+    @Test
+    public void testSkipBeforeChars() throws RedPenException {
+        SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before_chars", "「"), Configuration.builder().build());
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(new Sentence("きょうは「Coke 」を飲みたい。", 0));
+        assertEquals(0, errors.size());
+    }
+    
+    @Test
+    public void testSkipAfterChars() throws RedPenException {
+        SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_after_chars", "」"), Configuration.builder().build());
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(new Sentence("きょうは「 Coke」を飲みたい。", 0));
+        assertEquals(0, errors.size());
+    }
+    
+    @Test
+    public void testSkipBeforeAndAfterChars() throws RedPenException {
+        SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before_chars", "・「").addProperty("skip_after_chars", "・」"), Configuration.builder().build());
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(new Sentence("きょうは「Coke・Pepsi」を飲みたい。", 0));
+        assertEquals(0, errors.size());
+    }
+
 
     @Test
     public void testSupportedLanguages() {

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SpaceBetweenAlphabeticalWordValidatorTest.java
@@ -207,9 +207,9 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
     }
 
     @Test
-    public void testSkipBeforeChars() throws RedPenException {
+    public void testSkipBefore() throws RedPenException {
         SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
-        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before_chars", "「"), Configuration.builder().build());
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before", "「"), Configuration.builder().build());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(new Sentence("きょうは「Coke 」を飲みたい。", 0));
@@ -217,9 +217,9 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
     }
     
     @Test
-    public void testSkipAfterChars() throws RedPenException {
+    public void testSkipAfter() throws RedPenException {
         SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
-        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_after_chars", "」"), Configuration.builder().build());
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_after", "」"), Configuration.builder().build());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(new Sentence("きょうは「 Coke」を飲みたい。", 0));
@@ -227,9 +227,9 @@ public class SpaceBetweenAlphabeticalWordValidatorTest {
     }
     
     @Test
-    public void testSkipBeforeAndAfterChars() throws RedPenException {
+    public void testSkipBeforeAndAfter() throws RedPenException {
         SpaceBetweenAlphabeticalWordValidator validator = new SpaceBetweenAlphabeticalWordValidator();
-        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before_chars", "・「").addProperty("skip_after_chars", "・」"), Configuration.builder().build());
+        validator.preInit(new ValidatorConfiguration("SpaceBetweenAlphabeticalWord").addProperty("skip_before", "・「").addProperty("skip_after", "・」"), Configuration.builder().build());
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(new Sentence("きょうは「Coke・Pepsi」を飲みたい。", 0));


### PR DESCRIPTION
Add skip character of SpaceBetweenAlphabeticalWordValidator.

## New properties

* skip_before_chars
* skip_after_chars

## Examples

### Document file

```
iPhone は iPod・携帯電話・インターネットの融合。
```

### Configuration file

```
        <validator name="SpaceBetweenAlphabeticalWord">
            <property name="skip_before_chars" value="。、・（「『"/>
            <property name="skip_after_chars" value="。、・）」』"/>
        </validator>
```
