### PR TITLE
Add special handling for small letter in KatakanaEndHypen

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
@@ -60,12 +60,6 @@ public final class KatakanaEndHyphenValidator extends DictionaryValidator {
      */
     private static final char KATAKANA_MIDDLE_DOT = '・';
 
-    public static boolean isKatakanaEndHyphen(String katakana) {
-        return (DEFAULT_KATAKANA_LIMIT_LENGTH < katakana.length()
-                && katakana.charAt(katakana.length() - 1) == HYPHEN
-                && isEndWithSmallLetter(katakana));
-    }
-
     @Override
     public List<String> getSupportedLanguages() {
         return singletonList(Locale.JAPANESE.getLanguage());
@@ -86,9 +80,13 @@ public final class KatakanaEndHyphenValidator extends DictionaryValidator {
         this.checkKatakanaEndHyphen(sentence, katakana.toString(), sentence.getContent().length() - 1);
     }
 
-    private static boolean isEndWithSmallLetter(String katakana) {
-        if (katakana.length() <= 2) return false;
-        char c = katakana.charAt(katakana.length()-2);
+    public static boolean isKatakanaEndHyphen(String katakana) {
+        return (DEFAULT_KATAKANA_LIMIT_LENGTH < katakana.length() &&
+                katakana.charAt(katakana.length() - 1) == HYPHEN &&
+                checkCharacterBeforeHyphen(katakana.charAt(katakana.length() - 2)));
+    }
+
+    private static boolean checkCharacterBeforeHyphen(char c) {
         return c != 'ュ' && c != 'ャ' && c != 'ョ';
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
@@ -62,7 +62,8 @@ public final class KatakanaEndHyphenValidator extends DictionaryValidator {
 
     public static boolean isKatakanaEndHyphen(String katakana) {
         return (DEFAULT_KATAKANA_LIMIT_LENGTH < katakana.length()
-                && katakana.charAt(katakana.length() - 1) == HYPHEN);
+                && katakana.charAt(katakana.length() - 1) == HYPHEN
+                && isEndWithSmallLetter(katakana));
     }
 
     @Override
@@ -83,6 +84,12 @@ public final class KatakanaEndHyphenValidator extends DictionaryValidator {
             }
         }
         this.checkKatakanaEndHyphen(sentence, katakana.toString(), sentence.getContent().length() - 1);
+    }
+
+    private static boolean isEndWithSmallLetter(String katakana) {
+        if (katakana.length() <= 2) return false;
+        char c = katakana.charAt(katakana.length()-2);
+        return c != 'ュ' && c != 'ャ' && c != 'ョ';
     }
 
     private void checkKatakanaEndHyphen(Sentence sentence, String katakana, int position) {

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidatorTest.java
@@ -73,6 +73,15 @@ public class KatakanaEndHyphenValidatorTest {
     }
 
     @Test
+    public void testKatakanaOfLength2andHyphen() {
+        Sentence str = new Sentence("ポー", 0);
+        List<ValidationError> errors = new ArrayList<>();
+        validator.setErrorList(errors);
+        validator.validate(str);
+        assertEquals(str.toString(), 0, errors.size());
+    }
+
+    @Test
     public void testKatakanaOfLength3andHyphen() {
         Sentence str = new Sentence("ミラー", 0);
         List<ValidationError> errors = new ArrayList<>();
@@ -186,6 +195,24 @@ public class KatakanaEndHyphenValidatorTest {
                         .build());
 
         System.setProperty("REDPEN_HOME",new File("src/test/resources/").getAbsolutePath());
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        assertEquals(0, errors.get(documents.get(0)).size());
+    }
+
+    @Test
+    public void testEndWithSmallLetter() throws RedPenException {
+        Configuration config = Configuration.builder("ja")
+                .addValidatorConfig(new ValidatorConfiguration("KatakanaEndHyphen"))
+                .build();
+
+        List<Document> documents = new ArrayList<>();documents.add(
+                Document.builder()
+                        .addSection(1)
+                        .addParagraph()
+                        .addSentence(new Sentence("メニューは必要ですか", 1))
+                        .build());
+
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         assertEquals(0, errors.get(documents.get(0)).size());


### PR DESCRIPTION
This fix is to add special handling for Katakana words ends with small character such as "メニュー" or    "シチュー".