### PR TITLE
Set default locale to 'en-US' for testing

### DIFF
--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -116,7 +116,7 @@
                     <excludes>
                         <exclude>**/**$**</exclude>
                     </excludes>
-                    <argLine>${argLine} -Dfile.encoding=UTF-8</argLine>
+                    <argLine>${argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
In my environment (`LANG=ja_JP.UTF-8`), some tests are failed because the default locale is not properly set.

Here is the Maven log (excerpt):

```
$ ./mvnw test
...
Results :

Failed tests:   testErrorMessageIsProperlyFormatted(cc.redpen.validator.sentence.SuggestExpressionValidatorTest): expected:<[Found invalid word "info". Use the synonym "information" instead.]> but was:<[不正な単語 "info" がみつかりました．かわりに "information" を利用してください。]>
  noErrorsForShortWordsByDefault(cc.redpen.validator.sentence.DoubledWordValidatorTest): expected:<[Found repeated word "validator".]> but was:<[一文に二回以上利用されている単語 "validator" がみつかりました。]>
  testDoubledWordWithDifferentCase(cc.redpen.validator.sentence.DoubledWordValidatorTest): expected:<[Found repeated word "good".]> but was:<[一文に二回以上利用されている単語 "good" がみつかりました。]>
  testDoubledWord(cc.redpen.validator.sentence.DoubledWordValidatorTest): expected:<[Found repeated word "good".]> but was:<[一文に二回以上利用されている単語 "good" がみつかりました。]>
  detectJapaneseSuccessiveWord(cc.redpen.validator.sentence.SuccessiveWordValidatorTest): expected:<[Found word "は" repeated twice in succession.]> but was:<[単語 "は" は連続して使用されています。]>
  detectSuccessiveWordWithDifferentCase(cc.redpen.validator.sentence.SuccessiveWordValidatorTest): expected:<[Found word "welcome" repeated twice in succession.]> but was:<[単語 "welcome" は連続して使用されています。]>
  detectSuccessiveWord(cc.redpen.validator.sentence.SuccessiveWordValidatorTest): expected:<[Found word "is" repeated twice in succession.]> but was:<[単語 "is" は連続して使用されています。]>
  testNeedSpaceInMultiplePosition(cc.redpen.validator.sentence.SymbolWithSpaceValidatorTest): expected:<[Need whitespace after symbol ")"., Need whitespace before symbol "(".]> but was:<[シンボルの前にスペースが必要です (()。, シンボルの前にスペースが必要です ())。]>
  testNeedAfterSpace(cc.redpen.validator.sentence.SymbolWithSpaceValidatorTest): expected:<[Need whitespace after symbol ":".]> but was:<[シンボルの前にスペースが必要です (:)。]>
  testNeedBeforeSpace(cc.redpen.validator.sentence.SymbolWithSpaceValidatorTest): expected:<[Need whitespace before symbol "(".]> but was:<[シンボルの前にスペースが必要です (()。]>
  testReturnOnlyOneForHitBothBeforeAndAfter(cc.redpen.validator.sentence.SymbolWithSpaceValidatorTest): expected:<[Need whitespace before and after symbol "*".]> but was:<[シンボルの前にスペースが必要です (*)。]>

Tests run: 714, Failures: 11, Errors: 0, Skipped: 0
```