### PR TITLE
Fix bugs to flush error for level 0 section

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/section/EmptySectionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/EmptySectionValidator.java
@@ -3,6 +3,7 @@ package cc.redpen.validator.section;
 import cc.redpen.RedPenException;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
+import cc.redpen.model.Sentence;
 import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,19 +32,17 @@ public class EmptySectionValidator extends Validator {
 
     @Override
     public void validate(Section section) {
-        if (section.getLevel() >= sectionLevelLimit) {
+        if (0 == section.getLevel() || section.getLevel() >= sectionLevelLimit) {
             return;
         }
 
-        if (section.getLevel() == 0) {
-            return; // hot fix for auto generated level 0 sections.
-        }
+        Sentence header = section.getJoinedHeaderContents();
         if (section.getNumberOfParagraphs() == 0) {
-            addLocalizedError(section.getJoinedHeaderContents());
+            addLocalizedError(header, header.getContent());
         } else {
             for (Paragraph p : section.getParagraphs()) {
                 if (p.getNumberOfSentences() == 0) {
-                    addLocalizedError(section.getJoinedHeaderContents());
+                    addLocalizedError(header, header.getContent());
                     break;
                 }
             }

--- a/redpen-core/src/main/java/cc/redpen/validator/section/VoidSectionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/VoidSectionValidator.java
@@ -20,6 +20,7 @@ package cc.redpen.validator.section;
 import cc.redpen.RedPenException;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
+import cc.redpen.model.Sentence;
 import cc.redpen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,19 +37,17 @@ final public class VoidSectionValidator extends Validator {
 
     @Override
     public void validate(Section section) {
-        if (section.getLevel() >= sectionLevelLimit) {
+        if (0 == section.getLevel() || section.getLevel() >= sectionLevelLimit) {
             return;
         }
 
-        if (section.getLevel() == 0) {
-            return; // hot fix for auto generated level 0 sections.
-        }
+        Sentence header = section.getJoinedHeaderContents();
         if (section.getNumberOfParagraphs() == 0) {
-            addLocalizedError(section.getJoinedHeaderContents());
+            addLocalizedError(header, header.getContent());
         } else {
             for (Paragraph p : section.getParagraphs()) {
                 if (p.getNumberOfSentences() == 0) {
-                    addLocalizedError(section.getJoinedHeaderContents());
+                    addLocalizedError(header, header.getContent());
                     break;
                 }
             }

--- a/redpen-core/src/test/java/cc/redpen/validator/section/EmptySectionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/section/EmptySectionValidatorTest.java
@@ -46,7 +46,6 @@ class EmptySectionValidatorTest {
         List<ValidationError> errors = new ArrayList<>();
         validator.setErrorList(errors);
         validator.validate(document.getSection(0));
-
         assertEquals(1, errors.size());
     }
 


### PR DESCRIPTION
Fix error message of EmptySection (and VoidSection) to flush section names.