### PR TITLE
Add redpen-plugin module in .slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -2,3 +2,4 @@
 /redpen-cli/src/test/
 /redpen-core/src/test/
 /redpen-server/src/test/
+/redpen-plugin/


### PR DESCRIPTION
Fix the following error deploying RedPen to Heroku.

```
-----> Compressing...
 !     Compiled slug size: 555.9M is too large (max is 500M).
 !     See: http://devcenter.heroku.com/articles/slug-size
 !     Push failed
```