### PR TITLE
Enrich help message

### DIFF
--- a/redpen-cli/pom.xml
+++ b/redpen-cli/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -46,6 +46,13 @@ public final class Main {
 
     private static final int DEFAULT_LIMIT = 1;
 
+    private static final String HELP_HEADER = "\nValidate input documents with specified configuration settings.\n\nOptions:\n";
+
+    private static final String HELP_FOOTER = "\n\nExample:\n\n" +
+                                              "$redpen -c redpen-config.xml input.md\n\n" +
+                                              "Note:\n" +
+                                              "Setting files can be generated in http://redpen.herokuapp.com/\n";
+
     private Main() {
         super();
     }
@@ -279,7 +286,7 @@ public final class Main {
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(100);
         PrintWriter pw = new PrintWriter(System.err);
-        formatter.printHelp(pw, 80, PROGRAM + " [Options] [<INPUT FILE>]", null, opt, 1, 3, "");
+        formatter.printHelp(pw, 80, PROGRAM + " [Options] [<INPUT FILE>]", HELP_HEADER, opt, 1, 3, HELP_FOOTER);
         pw.flush();
     }
 


### PR DESCRIPTION
The following is the updated help message.

```
usage: redpen-cli [Options] [<INPUT FILE>]

Validate input documents with specified configuration settings.

Options:
 -c,--conf <CONF FILE>                Configuration file (REQUIRED)
 -f,--format <FORMAT>                 Input file format
                                      (markdown,plain,wiki,asciidoc,latex,rest)
 -h,--help                            Displays this help information and exits
 -l,--limit <LIMIT NUMBER>            Error limit number
 -L,--lang <LANGUAGE>                 Language of error messages
 -r,--result-format <RESULT FORMAT>   Output result format
                                      (json,json2,plain,plain2,xml)
 -s,--sentence <INPUT SENTENCES>      Input sentences
 -t,--threshold <THRESHOLD>           Threshold of error level (info, warn,
                                      error)
 -v,--version                         Displays version information and exits


Example:

$redpen -c redpen-config.xml input.md

Note:
Setting files can be generated in http://redpen.herokuapp.com/
```