### PR TITLE
Fix typo

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -264,7 +264,7 @@ public final class Main {
             case "review":
                 return "review";
             case "properties":
-                return "propery";
+                return "properties";
             case "rst":
             case "rest":
                 return "rest";


### PR DESCRIPTION
I run redpen for .properties file
```bash
find . -name "*.properties"  | xargs redpen
```
but got error.
```
[2018-08-01 12:14:47.077][INFO ] cc.redpen.Main - Configuration file: /usr/local/redpen-1.10.1/conf/redpen-conf-en.xml
[2018-08-01 12:14:47.084][INFO ] cc.redpen.config.ConfigurationLoader - Loading config from specified config file: "/usr/local/redpen-1.10.1/conf/redpen-conf-en.xml"
[2018-08-01 12:14:47.095][INFO ] cc.redpen.config.ConfigurationLoader - Succeeded to load configuration file
[2018-08-01 12:14:47.095][INFO ] cc.redpen.config.ConfigurationLoader - Language is set to "en"
[2018-08-01 12:14:47.095][WARN ] cc.redpen.config.ConfigurationLoader - No variant configuration...
[2018-08-01 12:14:47.142][INFO ] cc.redpen.config.ConfigurationLoader - No "symbols" block found in the configuration
[2018-08-01 12:14:47.145][INFO ] cc.redpen.config.SymbolTable - Default symbol settings are loaded
[2018-08-01 12:14:47.147][INFO ] cc.redpen.parser.SentenceExtractor - "[., ?, !]" are added as a end of sentence characters
[2018-08-01 12:14:47.147][INFO ] cc.redpen.parser.SentenceExtractor - "[', "]" are added as a right quotation characters
Exception in thread "main" java.lang.IllegalArgumentException: no such parser for :propery
	at cc.redpen.parser.DocumentParser.of(DocumentParser.java:99)
	at cc.redpen.Main.getDocuments(Main.java:219)
	at cc.redpen.Main.run(Main.java:196)
	at cc.redpen.Main.main(Main.java:60)
```

With `-f properties` option, redpen worked it.

I found typo in extension parser, and fixed it.