### PR TITLE
Fix typo in error message.

### DIFF
--- a/redpen-cli/bin/redpen
+++ b/redpen-cli/bin/redpen
@@ -36,7 +36,7 @@ if [ $? != 0 ]; then
     JAVA_CMD=$JAVA_HOME/bin/java
 
     if [ ! -x "$JAVA_CMD" ]; then
-      echo "Error: $JAVA_CMD is not execututable. Can not start RedPen" 1>&2
+      echo "Error: $JAVA_CMD is not executable. Can not start RedPen" 1>&2
       exit 1
     fi
   fi

--- a/redpen-server/bin/redpen-server
+++ b/redpen-server/bin/redpen-server
@@ -72,7 +72,7 @@ if [ $? != 0 ]; then
     JAVA_CMD=$JAVA_HOME/bin/java
 
     if [ ! -x "$JAVA_CMD" ]; then
-      echo "Error: $JAVA_CMD is not execututable. Can not start RedPen" 1>&2
+      echo "Error: $JAVA_CMD is not executable. Can not start RedPen" 1>&2
       exit 1
     fi
   fi


### PR DESCRIPTION
Fix type in error message.

Before `execututable` to after `executable`