### PR TITLE
Added the error level threshold feature to redpen-server

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -133,7 +133,7 @@ public final class Main {
         String resultFormat = "plain";
         String inputSentence = null;
         String language = "en";
-        String threshold = "info";
+        String threshold = "error";
 
         int limit = DEFAULT_LIMIT;
 

--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -133,7 +133,7 @@ public final class Main {
         String resultFormat = "plain";
         String inputSentence = null;
         String language = "en";
-        String threshold = "error";
+        String threshold = "info";
 
         int limit = DEFAULT_LIMIT;
 

--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -181,7 +181,7 @@ public class RedPen {
     public List<ValidationError> validate(Document document, String threshold) {
         List<Document> documents = new ArrayList<>();
         documents.add(document);
-        Map<Document, List<ValidationError>> documentListMap = validate(documents);
+        Map<Document, List<ValidationError>> documentListMap = validate(documents, threshold);
         return documentListMap.get(document);
     }
 

--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -46,6 +46,9 @@ public class RedPen {
     private final SentenceExtractor sentenceExtractor;
     private final List<Validator> validators;
 
+    private String errorLevel = "info";
+    public void setErrorLevel( String level ) { errorLevel = level; };
+
     /**
      * constructs RedPen with specified config file.
      *
@@ -140,7 +143,7 @@ public class RedPen {
      * @return list of validation errors
      */
     public Map<Document, List<ValidationError>> validate(List<Document> documents) {
-        return validate(documents, "error");
+        return validate(documents, errorLevel);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/RedPen.java
+++ b/redpen-core/src/main/java/cc/redpen/RedPen.java
@@ -46,9 +46,6 @@ public class RedPen {
     private final SentenceExtractor sentenceExtractor;
     private final List<Validator> validators;
 
-    private String errorLevel = "info";
-    public void setErrorLevel( String level ) { errorLevel = level; };
-
     /**
      * constructs RedPen with specified config file.
      *
@@ -143,7 +140,7 @@ public class RedPen {
      * @return list of validation errors
      */
     public Map<Document, List<ValidationError>> validate(List<Document> documents) {
-        return validate(documents, errorLevel);
+        return validate(documents, "error");
     }
 
     /**
@@ -165,12 +162,23 @@ public class RedPen {
     }
 
     /**
-     * validate the input document collection. Note that this method call is NOT thread safe. RedPen instances need to be crated for each thread.
+     * validate the input document. Note that this method call is NOT thread safe. RedPen instances need to be crated for each thread.
      *
      * @param document document to be validated
      * @return list of validation errors
      */
     public List<ValidationError> validate(Document document) {
+        return validate(document, "error");
+    }
+
+    /**
+     * validate the input document. Note that this method call is NOT thread safe. RedPen instances need to be crated for each thread.
+     *
+     * @param document document to be validated
+     * @param threshold threshold of error level
+     * @return list of validation errors
+     */
+    public List<ValidationError> validate(Document document, String threshold) {
         List<Document> documents = new ArrayList<>();
         documents.add(document);
         Map<Document, List<ValidationError>> documentListMap = validate(documents);

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -58,6 +58,7 @@ public class RedPenResource {
     private static final String DEFAULT_LANG = "en";
     private static final String DEFAULT_CONFIGURATION = "en";
     private static final String DEFAULT_FORMAT = "json";
+    private static final String DEFAULT_ERROR_LEVEL = "error";
 
     /*package*/ static final String MIME_TYPE_XML = "application/xml; charset=utf-8";
     /*package*/ static final String MIME_TYPE_JSON = "application/json; charset=utf-8";
@@ -99,6 +100,7 @@ public class RedPenResource {
                                      @FormParam("documentParser") @DefaultValue(DEFAULT_DOCUMENT_PARSER) String documentParser,
                                      @FormParam("lang") @DefaultValue(DEFAULT_CONFIGURATION) String lang,
                                      @FormParam("format") @DefaultValue(DEFAULT_FORMAT) String format,
+                                     @FormParam("errorLevel") @DefaultValue(DEFAULT_ERROR_LEVEL) String errorLevel,
                                      @FormParam("config") String config) throws RedPenException {
 
         LOG.info("Validating document");
@@ -108,6 +110,7 @@ public class RedPenResource {
         } else {
             redPen = new RedPen(new ConfigurationLoader().secure().loadFromString(config));
         }
+	redPen.setErrorLevel( errorLevel );
         Document parsedDocument = redPen.parse(DocumentParser.of(documentParser), document);
         List<ValidationError> errors = redPen.validate(parsedDocument);
 

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -110,9 +110,8 @@ public class RedPenResource {
         } else {
             redPen = new RedPen(new ConfigurationLoader().secure().loadFromString(config));
         }
-        redPen.setErrorLevel( errorLevel );
         Document parsedDocument = redPen.parse(DocumentParser.of(documentParser), document);
-        List<ValidationError> errors = redPen.validate(parsedDocument);
+        List<ValidationError> errors = redPen.validate(parsedDocument, errorLevel);
 
         Formatter formatter = FormatterUtils.getFormatterByName(format);
 

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -110,7 +110,7 @@ public class RedPenResource {
         } else {
             redPen = new RedPen(new ConfigurationLoader().secure().loadFromString(config));
         }
-	redPen.setErrorLevel( errorLevel );
+        redPen.setErrorLevel( errorLevel );
         Document parsedDocument = redPen.parse(DocumentParser.of(documentParser), document);
         List<ValidationError> errors = redPen.validate(parsedDocument);
 


### PR DESCRIPTION
`redpen-server` was not working correctly with the new feature of "error threshold" that there was no way to specify to get `info` or `warn`.

With this commit they can request an error level by sending `errorLevel` within the POST form such as:

```
  var formData = {
    'document': body.getText(),
    'lang' : 'ja',
    'format' : 'json2',
    'documentParser' : 'plain',
    'config' : configs,
    'errorLevel' : 'warn'
  };
```
