### PR TITLE
Fixed false positive for "食べられる" (potential verb) by JapaneseBrokenExpression

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
@@ -39,7 +39,9 @@ public class JapaneseBrokenExpressionValidator extends Validator {
         for (int i = 0; i < (tokens.size() - 1); ++i) {
             final TokenElement p = tokens.get(i);
             final List<String> ptags = p.getTags();
-            if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") && ptags.get(3).equals("未然形")) {
+            if (ptags.get(0).equals("動詞") && p.getSurface().equals("見れる")) {
+                addLocalizedError(sentence, p.getSurface());
+            } else if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") && ptags.get(3).equals("未然形")) {
                 final TokenElement q = tokens.get(i+1);
                 final List<String> qtags = q.getTags();
                 if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && q.getSurface().startsWith("られ")) {

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
@@ -42,7 +42,7 @@ public class JapaneseBrokenExpressionValidator extends Validator {
             if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") && ptags.get(3).equals("未然形")) {
                 final TokenElement q = tokens.get(i+1);
                 final List<String> qtags = q.getTags();
-                if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && qtags.get(2).equals("一段") && qtags.get(3).equals("未然形") && q.getSurface().equals("られ")) {
+                if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && q.getSurface().startsWith("られ")) {
                 } else {
                     addLocalizedError(sentence, p.getSurface());
                 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidatorTest.java
@@ -40,6 +40,10 @@ class JapaneseBrokenExpressionValidatorTest {
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("PDF形式の文書を見れない環境がある。", 1))
+                .addSentence(new Sentence("PDF形式の文書を見れる環境だ。", 2))
+                .addSentence(new Sentence("熱くて寝れない", 3))
+                .addSentence(new Sentence("今日はぐっすり寝れる", 4))
+
                 .build());
 
         Configuration config = Configuration.builder("ja")
@@ -48,7 +52,7 @@ class JapaneseBrokenExpressionValidatorTest {
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
-        assertEquals(1, errors.get(documents.get(0)).size());
+        assertEquals(4, errors.get(documents.get(0)).size());
     }
 
     @Test
@@ -58,6 +62,9 @@ class JapaneseBrokenExpressionValidatorTest {
                 .addSection(1)
                 .addParagraph()
                 .addSentence(new Sentence("PDF形式の文書を見られない環境がある。", 1))
+                .addSentence(new Sentence("PDF形式の文章を見られる環境だ。", 2))
+                .addSentence(new Sentence("熱くて寝られない", 3))
+                .addSentence(new Sentence("今日はぐっすり寝られる", 4))
                 .build());
 
         Configuration config = Configuration.builder("ja")


### PR DESCRIPTION
JapaneseBrokenExpression would cause false positives for potential verb.
It would assert error for "食べられる", "見られる", "寝られる", and so on.

What I did:

* Added tests for checking this
* Fixed code (JapaneseBrokenExpression only).
* Added special case handling

### About special case

The tokenizer will parse ”見れる" as one token.
It might depends on dicts of Kuromoji or so.

This issue looks similar https://github.com/takuyaa/kuromoji.js/issues/28

I think we need to add other special cases (if there are).

### About baseForm of tokens

It's better to use BaseForm in this logic

```java
q.getSurface().startsWith("られ")
```
Best way.

```java
q.getBaseForm().equals("られる")
```

But to get baseForm, we need to change TokenElement and NoelogdJapaneseTokenizer.
It looks other Validators won't use BaseForm of each tokens, and it's only necessary with Japanese.
So in this PullRequest, I avoided to change them.

### As ScreenShot

Before

![スクリーンショット 2020-10-16 13-37-20](https://user-images.githubusercontent.com/854049/96213816-d363e000-0fb4-11eb-857f-2f146d363568.png)

After

![スクリーンショット 2020-10-16 13-37-54](https://user-images.githubusercontent.com/854049/96213825-d959c100-0fb4-11eb-8d4d-da6547ab5a9f.png)

### Note

I'm not good at Java, so feel free to change my code and syntax as you like.
