### PR TITLE
Ra drop improvement

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/tokenizer/NeologdJapaneseTokenizer.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/NeologdJapaneseTokenizer.java
@@ -71,7 +71,8 @@ public class NeologdJapaneseTokenizer implements RedPenTokenizer {
             tokens.add(new TokenElement(surface,
                     getTagList(posAttr, inflectionAttr),
                     offsetAttr.startOffset(),
-                    readAttr.getReading()
+                    readAttr.getReading(),
+                    baseAttr.getBaseForm()
             ));
         }
         tokenizer.close();

--- a/redpen-core/src/main/java/cc/redpen/tokenizer/TokenElement.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/TokenElement.java
@@ -36,11 +36,19 @@ public class TokenElement implements Serializable {
     // token reading
     final private String reading;
 
-    public TokenElement(String word, List<String> tagList, int offset, String reading) {
+    // the base form of the token
+    final private String baseForm;
+
+    public TokenElement(String word, List<String> tagList, int offset, String reading, String baseForm) {
         surface = word;
         tags = Collections.unmodifiableList(tagList);
         this.offset = offset;
         this.reading = reading;
+        this.baseForm = baseForm;
+    }
+
+    public TokenElement(String word, List<String> tagList, int offset, String reading) {
+        this(word, tagList, offset, reading, null);
     }
 
     public TokenElement(String word, List<String> tagList, int offset) {
@@ -60,6 +68,8 @@ public class TokenElement implements Serializable {
     }
 
     public String getReading() { return reading; }
+
+    public String getBaseForm() { return (baseForm!=null) ? baseForm : surface; }
 
     @Override
     public boolean equals(Object o) {

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
@@ -19,6 +19,7 @@ package cc.redpen.validator.sentence;
 
 import cc.redpen.model.Sentence;
 import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.tokenizer.NeologdJapaneseTokenizer;
 import cc.redpen.validator.Validator;
 
 import java.util.List;
@@ -39,14 +40,40 @@ public class JapaneseBrokenExpressionValidator extends Validator {
         for (int i = 0; i < (tokens.size() - 1); ++i) {
             final TokenElement p = tokens.get(i);
             final List<String> ptags = p.getTags();
-            if (ptags.get(0).equals("動詞") && p.getSurface().equals("見れる")) {
-                addLocalizedError(sentence, p.getSurface());
-            } else if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") && ptags.get(3).equals("未然形")) {
-                final TokenElement q = tokens.get(i+1);
-                final List<String> qtags = q.getTags();
-                if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && q.getSurface().startsWith("られ")) {
-                } else {
-                    addLocalizedError(sentence, p.getSurface());
+            System.out.println( p.getSurface() );
+            System.out.println( ptags );
+            if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") ) {
+                if( ptags.get(3).equals("未然形") )
+                {
+                    final TokenElement q = tokens.get(i+1);
+                    final List<String> qtags = q.getTags();
+                    System.out.println(qtags);
+                    System.out.println(q.getBaseForm());
+                    if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && q.getBaseForm().equals("れる")) {
+                        addLocalizedError(sentence, p.getSurface());
+                        continue;
+                    }
+                }
+                System.out.println( p.getBaseForm() );
+                if( p.getBaseForm().endsWith("れる") )
+                {
+                    if( p.getBaseForm().endsWith("られる") )
+                    {
+                        // need to check "Ra-Ire" error
+                        continue;
+                    }
+                    else
+                    {
+                        String nverb = p.getBaseForm().replaceFirst("れる$","る");
+                        System.out.println(nverb);
+                        NeologdJapaneseTokenizer tokenizer = new NeologdJapaneseTokenizer();
+                        List<TokenElement> t = tokenizer.tokenize(nverb);
+                        String inflectionType = t.get(0).getTags().get(2);
+                        if( inflectionType.startsWith("一段") || inflectionType.startsWith("カ変") )
+                        {
+                            addLocalizedError(sentence, p.getSurface());
+                        }
+                    }
                 }
             }
         }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidator.java
@@ -40,21 +40,16 @@ public class JapaneseBrokenExpressionValidator extends Validator {
         for (int i = 0; i < (tokens.size() - 1); ++i) {
             final TokenElement p = tokens.get(i);
             final List<String> ptags = p.getTags();
-            System.out.println( p.getSurface() );
-            System.out.println( ptags );
             if (ptags.get(0).equals("動詞") && ptags.get(1).equals("自立") && ptags.get(2).equals("一段") ) {
                 if( ptags.get(3).equals("未然形") )
                 {
                     final TokenElement q = tokens.get(i+1);
                     final List<String> qtags = q.getTags();
-                    System.out.println(qtags);
-                    System.out.println(q.getBaseForm());
                     if (qtags.get(0).equals("動詞") && qtags.get(1).equals("接尾") && q.getBaseForm().equals("れる")) {
                         addLocalizedError(sentence, p.getSurface());
                         continue;
                     }
                 }
-                System.out.println( p.getBaseForm() );
                 if( p.getBaseForm().endsWith("れる") )
                 {
                     if( p.getBaseForm().endsWith("られる") )
@@ -65,7 +60,6 @@ public class JapaneseBrokenExpressionValidator extends Validator {
                     else
                     {
                         String nverb = p.getBaseForm().replaceFirst("れる$","る");
-                        System.out.println(nverb);
                         NeologdJapaneseTokenizer tokenizer = new NeologdJapaneseTokenizer();
                         List<TokenElement> t = tokenizer.tokenize(nverb);
                         String inflectionType = t.get(0).getTags().get(2);

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseBrokenExpressionValidatorTest.java
@@ -43,7 +43,8 @@ class JapaneseBrokenExpressionValidatorTest {
                 .addSentence(new Sentence("PDF形式の文書を見れる環境だ。", 2))
                 .addSentence(new Sentence("熱くて寝れない", 3))
                 .addSentence(new Sentence("今日はぐっすり寝れる", 4))
-
+                .addSentence(new Sentence("明日来れますか。", 5))
+                .addSentence(new Sentence("これはもう着れない。", 6))
                 .build());
 
         Configuration config = Configuration.builder("ja")
@@ -52,7 +53,7 @@ class JapaneseBrokenExpressionValidatorTest {
 
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
-        assertEquals(4, errors.get(documents.get(0)).size());
+        assertEquals(6, errors.get(documents.get(0)).size());
     }
 
     @Test
@@ -65,6 +66,9 @@ class JapaneseBrokenExpressionValidatorTest {
                 .addSentence(new Sentence("PDF形式の文章を見られる環境だ。", 2))
                 .addSentence(new Sentence("熱くて寝られない", 3))
                 .addSentence(new Sentence("今日はぐっすり寝られる", 4))
+                .addSentence(new Sentence("明日来られますか。", 5))
+                .addSentence(new Sentence("これはもう着られない。", 6))
+                .addSentence(new Sentence("これはもう切れない。", 7))
                 .build());
 
         Configuration config = Configuration.builder("ja")


### PR DESCRIPTION
Concerning the "Ra-Drop" error, as @hirokiky pointed out, the dictionary includes a wrong expression "見れる" as a correct word. It makes the detection of an error difficult.

We cannot rely on the dictionary that they do not have other such cases, so I tried to implement the logic by adding baseForm information as:

- if the words are "一段動詞・未然" + baseForm "れる", it is an error.
- if the baseForm of a verb ends with "れる" and not with "られる" ( a potential verb ):
-- replace the "れる" with "る" to make it a normal verb ( such as "見れる" -> "見る" )
-- if its inflection type is "一段" or "カ変", it is an error. ( the inflection type of "見る" is "一段", so it is an error. )

If there are no exceptional wrong verbs in the dictionary, @hirokiky 's method combined with baseForm information would be better because it is fast and simple.

![image](https://user-images.githubusercontent.com/13112228/96983786-3f1cee80-155b-11eb-9ab6-0b66c96bd280.png)


