### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: java
 
 sudo: required
 
+cache:
+  directories:
+  - $HOME/.m2
+
 jdk:
   - openjdk10
   - openjdk11


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.