### PR TITLE
Added position to JapaneseAmbiguousNounConjunctionValidator

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseAmbiguousNounConjunctionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/JapaneseAmbiguousNounConjunctionValidator.java
@@ -73,7 +73,8 @@ public class JapaneseAmbiguousNounConjunctionValidator extends DictionaryValidat
                 } else {
                     String surface = String.join("", surfaces);
                     if (!inDictionary(surface)) {
-                        addLocalizedError(sentence, surface);
+                        int offset = tokenElement.getOffset();
+                        addLocalizedErrorWithPosition(sentence, offset - surface.length(), offset - 1, surface);
                     }
                     stackSize = 0;
                 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseAmbiguousNounConjunctionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/JapaneseAmbiguousNounConjunctionValidatorTest.java
@@ -49,6 +49,10 @@ class JapaneseAmbiguousNounConjunctionValidatorTest {
         RedPen redPen = new RedPen(config);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         assertEquals(1, errors.get(documents.get(0)).size());
+        assertEquals(0, (int) errors.get(documents.get(0)).get(0)
+                .getStartPosition().map(it -> it.offset).orElse(-1));
+        assertEquals(9, (int) errors.get(documents.get(0)).get(0)
+                .getEndPosition().map(it -> it.offset).orElse(-1));
     }
 
     @Test


### PR DESCRIPTION
JapaneseAmbiguousNounConjunctionValidatorの出力でStartPositionとEndPositionが追記されるようにしました。
開始位置と終了位置はValidate確定時の単語の位置とメッセージに代入する文字列長から計算しています。

Added StartPosition and EndPosition in the output of JapaneseAmbiguousNounConjunctionValidator. 
The start position and end position are calculated from the position of the word when Validate is confirmed and the length of the character string to be assigned to the message.